### PR TITLE
Add configurable `module` parameter for DSPy module selection

### DIFF
--- a/tactus/dspy/agent.py
+++ b/tactus/dspy/agent.py
@@ -6,7 +6,7 @@ This module provides an Agent implementation built on top of DSPy primitives
 as the original pydantic_ai-based Agent while using DSPy for LLM interactions.
 
 The Agent uses:
-- Module with chain_of_thought strategy for reasoning
+- Configurable DSPy module (default: Predict for simple pass-through, or ChainOfThought for reasoning)
 - History for conversation management
 - Tool handling similar to DSPy's ReAct pattern
 - Unified mocking via Mocks {} primitive
@@ -56,6 +56,7 @@ class DSPyAgentHandle:
         temperature: float = 0.7,
         max_tokens: Optional[int] = None,
         model_type: Optional[str] = None,
+        module: str = "Predict",
         initial_message: Optional[str] = None,
         registry: Any = None,
         mock_manager: Any = None,
@@ -78,6 +79,9 @@ class DSPyAgentHandle:
             temperature: Model temperature (default: 0.7)
             max_tokens: Maximum tokens for response
             model_type: Model type for DSPy (e.g., "chat", "responses" for reasoning models)
+            module: DSPy module type to use (default: "Predict"). Options:
+                - "Predict": Simple pass-through prediction (no reasoning traces)
+                - "ChainOfThought": Adds step-by-step reasoning before response
             initial_message: Initial message to send on first turn if no inject
             registry: Optional Registry instance for accessing mocks
             mock_manager: Optional MockManager instance for checking mocks
@@ -98,6 +102,7 @@ class DSPyAgentHandle:
         self.temperature = temperature
         self.max_tokens = max_tokens
         self.model_type = model_type
+        self.module = module
         self.initial_message = initial_message
         self.registry = registry
         self.mock_manager = mock_manager
@@ -267,6 +272,31 @@ class DSPyAgentHandle:
             cost_stats=cost_stats,
         )
 
+    def _module_to_strategy(self, module: str) -> str:
+        """
+        Map DSPy module name to internal strategy name.
+
+        Args:
+            module: DSPy module name (e.g., "Predict", "ChainOfThought")
+
+        Returns:
+            Internal strategy name for create_module()
+
+        Raises:
+            ValueError: If module name is not recognized
+        """
+        mapping = {
+            "Predict": "predict",
+            "ChainOfThought": "chain_of_thought",
+            # Future modules can be added here:
+            # "ReAct": "react",
+            # "ProgramOfThought": "program_of_thought",
+        }
+        strategy = mapping.get(module)
+        if strategy is None:
+            raise ValueError(f"Unknown module '{module}'. Supported: {list(mapping.keys())}")
+        return strategy
+
     def _build_module(self) -> TactusModule:
         """Build the internal DSPy module for this agent."""
         # Create a signature for agent turns
@@ -284,7 +314,7 @@ class DSPyAgentHandle:
             f"{self.name}_module",
             {
                 "signature": signature,
-                "strategy": "chain_of_thought",
+                "strategy": self._module_to_strategy(self.module),
             },
         )
 
@@ -874,6 +904,7 @@ def create_dspy_agent(
             - model: Model name (LiteLLM format)
             - tools: List of tools
             - toolsets: List of toolset names
+            - module: DSPy module type (default: "Predict"). Options: "Predict", "ChainOfThought"
             - Other optional configuration
         registry: Optional Registry instance for accessing mocks
         mock_manager: Optional MockManager instance for checking mocks
@@ -901,6 +932,7 @@ def create_dspy_agent(
         temperature=config.get("temperature", 0.7),
         max_tokens=config.get("max_tokens"),
         model_type=config.get("model_type"),
+        module=config.get("module", "Predict"),
         initial_message=config.get("initial_message"),
         registry=registry,
         mock_manager=mock_manager,
@@ -921,6 +953,7 @@ def create_dspy_agent(
                 "temperature",
                 "max_tokens",
                 "model_type",
+                "module",
                 "initial_message",
                 "log_handler",
                 "disable_streaming",

--- a/tactus/dspy/module.py
+++ b/tactus/dspy/module.py
@@ -90,11 +90,16 @@ class TactusModule:
         return schema
 
     def _create_module(self) -> dspy.Module:
-        """Create the appropriate DSPy module based on strategy."""
+        """Create the appropriate DSPy module based on strategy.
+
+        Passes through any extra kwargs to the DSPy module constructor,
+        allowing access to DSPy-specific options like temperature, max_tokens,
+        rationale_field (for ChainOfThought), etc.
+        """
         if self.strategy == "predict":
-            return dspy.Predict(self.signature)
+            return dspy.Predict(self.signature, **self.kwargs)
         elif self.strategy == "chain_of_thought":
-            return dspy.ChainOfThought(self.signature)
+            return dspy.ChainOfThought(self.signature, **self.kwargs)
         elif self.strategy == "react":
             # ReAct requires tools - will be implemented in Step 5.1
             raise NotImplementedError("ReAct strategy not yet implemented. Coming in Step 5.1.")

--- a/tests/dspy/test_module_parameter.py
+++ b/tests/dspy/test_module_parameter.py
@@ -1,0 +1,142 @@
+"""
+Tests for DSPy module parameter configuration.
+
+Tests that the `module` parameter correctly selects DSPy modules:
+- Default "Predict" for simple pass-through
+- "ChainOfThought" for reasoning traces
+"""
+
+import pytest
+
+from tactus.dspy.agent import DSPyAgentHandle, create_dspy_agent
+from tactus.dspy.config import reset_lm_configuration
+
+
+class TestModuleParameterConfiguration:
+    """Test module parameter configuration."""
+
+    def setup_method(self):
+        """Reset LM configuration before each test."""
+        reset_lm_configuration()
+
+    def test_default_module_is_predict(self):
+        """Test that default module is Predict (simple pass-through)."""
+        agent = DSPyAgentHandle(
+            name="test_agent",
+            system_prompt="Test prompt",
+            model="openai/gpt-4o-mini",
+        )
+        assert agent.module == "Predict"
+
+    def test_module_can_be_set_to_chain_of_thought(self):
+        """Test that module can be explicitly set to ChainOfThought."""
+        agent = DSPyAgentHandle(
+            name="test_agent",
+            system_prompt="Test prompt",
+            model="openai/gpt-4o-mini",
+            module="ChainOfThought",
+        )
+        assert agent.module == "ChainOfThought"
+
+    def test_module_to_strategy_mapping_predict(self):
+        """Test that Predict maps to 'predict' strategy."""
+        agent = DSPyAgentHandle(
+            name="test_agent",
+            system_prompt="Test prompt",
+            model="openai/gpt-4o-mini",
+            module="Predict",
+        )
+        assert agent._module_to_strategy("Predict") == "predict"
+
+    def test_module_to_strategy_mapping_chain_of_thought(self):
+        """Test that ChainOfThought maps to 'chain_of_thought' strategy."""
+        agent = DSPyAgentHandle(
+            name="test_agent",
+            system_prompt="Test prompt",
+            model="openai/gpt-4o-mini",
+            module="ChainOfThought",
+        )
+        assert agent._module_to_strategy("ChainOfThought") == "chain_of_thought"
+
+    def test_unknown_module_raises_error(self):
+        """Test that unknown module names raise ValueError."""
+        agent = DSPyAgentHandle(
+            name="test_agent",
+            system_prompt="Test prompt",
+            model="openai/gpt-4o-mini",
+        )
+        with pytest.raises(ValueError, match="Unknown module"):
+            agent._module_to_strategy("UnknownModule")
+
+
+class TestCreateDspyAgentModule:
+    """Test module parameter in create_dspy_agent factory."""
+
+    def setup_method(self):
+        """Reset LM configuration before each test."""
+        reset_lm_configuration()
+
+    def test_create_dspy_agent_default_module(self):
+        """Test that create_dspy_agent uses Predict by default."""
+        agent = create_dspy_agent(
+            name="test_agent",
+            config={
+                "system_prompt": "Test prompt",
+                "model": "openai/gpt-4o-mini",
+            },
+        )
+        assert agent.module == "Predict"
+
+    def test_create_dspy_agent_explicit_module(self):
+        """Test that create_dspy_agent accepts explicit module parameter."""
+        agent = create_dspy_agent(
+            name="test_agent",
+            config={
+                "system_prompt": "Test prompt",
+                "model": "openai/gpt-4o-mini",
+                "module": "ChainOfThought",
+            },
+        )
+        assert agent.module == "ChainOfThought"
+
+    def test_create_dspy_agent_predict_module(self):
+        """Test that create_dspy_agent accepts Predict module explicitly."""
+        agent = create_dspy_agent(
+            name="test_agent",
+            config={
+                "system_prompt": "Test prompt",
+                "model": "openai/gpt-4o-mini",
+                "module": "Predict",
+            },
+        )
+        assert agent.module == "Predict"
+
+
+class TestModuleBuildsCorrectly:
+    """Test that the internal DSPy module is built with correct strategy."""
+
+    def setup_method(self):
+        """Reset LM configuration before each test."""
+        reset_lm_configuration()
+
+    def test_predict_module_uses_predict_strategy(self):
+        """Test that Predict module uses predict strategy internally."""
+        agent = DSPyAgentHandle(
+            name="test_agent",
+            system_prompt="Test prompt",
+            model="openai/gpt-4o-mini",
+            module="Predict",
+        )
+        # The internal module should have the correct strategy
+        assert agent._module.strategy == "predict"
+
+    def test_chain_of_thought_module_uses_cot_strategy(self):
+        """Test that ChainOfThought module uses chain_of_thought strategy internally."""
+        agent = DSPyAgentHandle(
+            name="test_agent",
+            system_prompt="Test prompt",
+            model="openai/gpt-4o-mini",
+            module="ChainOfThought",
+        )
+        # The internal module should have the correct strategy
+        assert agent._module.strategy == "chain_of_thought"


### PR DESCRIPTION
feat(agent): add configurable `module` parameter for DSPy module selection

Add `module` parameter to Agent to select which DSPy module handles predictions:
- Default: "Predict" for simple pass-through (no reasoning traces)
- Optional: "ChainOfThought" for step-by-step reasoning

This makes Tactus a thin layer over DSPy rather than hardcoding ChainOfThought, which was causing verbose reasoning traces even for simple hello-world examples.

Changes:
- Add `module` parameter to DSPyAgentHandle (default: "Predict")
- Add `_module_to_strategy()` helper to map module names to internal strategies
- Fix kwargs pass-through in module.py so DSPy-specific options reach DSPy
- Add comprehensive tests for module parameter configuration

Usage:
```lua
-- Simple (default Predict - no reasoning traces)
World = Agent { system_prompt = "Your name is World." }

-- With reasoning traces
Thinker = Agent { system_prompt = "...", module = "ChainOfThought" }
```