### PR TITLE
Improve CLI logging (level/format) + fs helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1437,6 +1437,21 @@ tactus run workflow.tac  # If procedure has required inputs, you'll be prompted
 tactus run workflow.tac --storage file --storage-path ./data
 ```
 
+#### Logging Options
+
+The `run` command supports filtering and formatting logs:
+
+```bash
+# Show less/more output
+tactus run workflow.tac --log-level warning
+tactus run workflow.tac --log-level debug
+
+# Choose a log format
+tactus run workflow.tac --log-format rich      # default, grouped timestamps
+tactus run workflow.tac --log-format terminal  # no timestamps, higher-signal terminal output
+tactus run workflow.tac --log-format raw       # one-line-per-record, timestamped (CloudWatch-friendly)
+```
+
 The CLI automatically parses parameter types:
 - **Strings**: Direct values or quoted strings
 - **Numbers**: Integers or floats are auto-detected

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -2457,6 +2457,24 @@ File.write(path, contents)
 File.exists(path)
 ```
 
+### Filesystem Helpers (stdlib)
+
+Workflows sometimes need to enumerate files within the sandboxed working directory (for example, iterating over documents to lint or review). Use the filesystem helper module:
+
+```lua
+local fs = require("tactus.io.fs")
+
+-- List entries in a directory (relative paths)
+local entries = fs.list_dir("chapters", {files_only = true, sort = true})
+
+-- Glob files (relative paths)
+local qmd_files = fs.glob("chapters/*.qmd", {sort = true})
+```
+
+**Security model:** Paths are restricted to the procedure working directory; absolute paths and path traversal (`..`) are rejected.
+
+**Determinism:** Filesystem contents can change between runs; wrap file enumeration and reads in `Step.checkpoint()` for durable workflows.
+
 ---
 
 ## Matchers

--- a/tactus/adapters/cli_hitl.py
+++ b/tactus/adapters/cli_hitl.py
@@ -32,7 +32,7 @@ class CLIHITLHandler:
             console: Rich Console instance (creates new one if not provided)
         """
         self.console = console or Console()
-        logger.info("CLIHITLHandler initialized")
+        logger.debug("CLIHITLHandler initialized")
 
     def request_interaction(self, procedure_id: str, request: HITLRequest) -> HITLResponse:
         """
@@ -45,7 +45,7 @@ class CLIHITLHandler:
         Returns:
             HITLResponse with user's response
         """
-        logger.info(f"HITL request: {request.request_type} - {request.message}")
+        logger.debug(f"HITL request: {request.request_type} - {request.message}")
 
         # Display the request in a panel
         self.console.print()

--- a/tactus/adapters/cost_collector_log.py
+++ b/tactus/adapters/cost_collector_log.py
@@ -1,0 +1,56 @@
+"""
+Cost-only log handler for headless/sandbox runs.
+
+Collects CostEvent instances so the runtime can report total_cost/total_tokens,
+without enabling streaming UI behavior.
+"""
+
+from __future__ import annotations
+
+import logging
+import json
+from typing import List
+
+from tactus.protocols.models import CostEvent, LogEvent
+
+logger = logging.getLogger(__name__)
+
+
+class CostCollectorLogHandler:
+    """
+    Minimal LogHandler for sandbox runs.
+
+    This is useful in environments like Docker sandboxes where stdout is reserved
+    for protocol output, but we still want:
+    - accurate cost accounting (CostEvent)
+    - basic procedure logging (LogEvent) via stderr/Python logging
+    """
+
+    supports_streaming = False
+
+    def __init__(self):
+        self.cost_events: List[CostEvent] = []
+        logger.debug("CostCollectorLogHandler initialized")
+
+    def log(self, event: LogEvent) -> None:
+        if isinstance(event, CostEvent):
+            self.cost_events.append(event)
+            return
+
+        # Preserve useful procedure logs even when no IDE callback is present.
+        if isinstance(event, LogEvent):
+            event_logger = logging.getLogger(event.logger_name or "procedure")
+
+            msg = event.message
+            if event.context:
+                msg = f"{msg}\nContext: {json.dumps(event.context, indent=2, default=str)}"
+
+            level = (event.level or "INFO").upper()
+            if level == "DEBUG":
+                event_logger.debug(msg)
+            elif level in ("WARN", "WARNING"):
+                event_logger.warning(msg)
+            elif level == "ERROR":
+                event_logger.error(msg)
+            else:
+                event_logger.info(msg)

--- a/tactus/cli/app.py
+++ b/tactus/cli/app.py
@@ -110,15 +110,92 @@ def load_tactus_config():
         return {}
 
 
-def setup_logging(verbose: bool = False):
-    """Setup logging with rich handler."""
-    level = logging.DEBUG if verbose else logging.INFO
+_LOG_LEVELS = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "warn": logging.WARNING,
+    "error": logging.ERROR,
+    "critical": logging.CRITICAL,
+}
 
-    logging.basicConfig(
-        level=level,
-        format="%(message)s",
-        handlers=[RichHandler(console=console, show_path=False, rich_tracebacks=True)],
-    )
+_LOG_FORMATS = {"rich", "terminal", "raw"}
+
+
+class _TerminalLogHandler(logging.Handler):
+    """Minimal, high-signal terminal logger (no timestamps/levels)."""
+
+    def __init__(self, console: Console):
+        super().__init__()
+        self._console = console
+        self.setFormatter(logging.Formatter("%(message)s"))
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            message = self.format(record)
+
+            # Make procedure-level logs the most prominent.
+            if record.name.startswith("procedure"):
+                style = "bold"
+            elif record.levelno >= logging.ERROR:
+                style = "bold red"
+            elif record.levelno >= logging.WARNING:
+                style = "yellow"
+            elif record.levelno <= logging.DEBUG:
+                style = "dim"
+            else:
+                style = ""
+
+            self._console.print(message, style=style, markup=False, highlight=False)
+        except Exception:
+            self.handleError(record)
+
+
+def setup_logging(
+    verbose: bool = False,
+    log_level: Optional[str] = None,
+    log_format: str = "rich",
+) -> None:
+    """Setup CLI logging (level + format)."""
+    if log_level is None:
+        level = logging.DEBUG if verbose else logging.INFO
+    else:
+        key = str(log_level).strip().lower()
+        if key not in _LOG_LEVELS:
+            raise typer.BadParameter(
+                f"Invalid --log-level '{log_level}'. "
+                f"Use one of: {', '.join(sorted(_LOG_LEVELS.keys()))}"
+            )
+        level = _LOG_LEVELS[key]
+
+    fmt = (log_format or "rich").strip().lower()
+    if fmt not in _LOG_FORMATS:
+        raise typer.BadParameter(
+            f"Invalid --log-format '{log_format}'. Use one of: {', '.join(sorted(_LOG_FORMATS))}"
+        )
+
+    # Default: rich logs (group repeated timestamps).
+    if fmt == "rich":
+        handler: logging.Handler = RichHandler(
+            console=console,
+            show_path=False,
+            rich_tracebacks=True,
+            omit_repeated_times=True,
+        )
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logging.basicConfig(level=level, format="%(message)s", handlers=[handler], force=True)
+        return
+
+    # Raw logs: one line per entry, CloudWatch-friendly.
+    if fmt == "raw":
+        handler = logging.StreamHandler(stream=sys.stderr)
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+        logging.basicConfig(level=level, handlers=[handler], force=True)
+        return
+
+    # Terminal logs: no timestamps/levels, color by signal.
+    handler = _TerminalLogHandler(console)
+    logging.basicConfig(level=level, handlers=[handler], force=True)
 
 
 def _parse_value(value_str: str, field_type: str) -> Any:
@@ -328,6 +405,12 @@ def run(
         None, envvar="OPENAI_API_KEY", help="OpenAI API key"
     ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose logging"),
+    log_level: Optional[str] = typer.Option(
+        None, "--log-level", help="Log level: debug, info, warning, error, critical"
+    ),
+    log_format: str = typer.Option(
+        "rich", "--log-format", help="Log format: rich (default), terminal, raw"
+    ),
     param: Optional[list[str]] = typer.Option(None, help="Parameters in format key=value"),
     interactive: bool = typer.Option(
         False, "--interactive", "-i", help="Interactively prompt for all inputs"
@@ -375,7 +458,7 @@ def run(
         # Use real implementation for specific tools while mocking others
         tactus run workflow.tac --mock-all --real done
     """
-    setup_logging(verbose)
+    setup_logging(verbose=verbose, log_level=log_level, log_format=log_format)
 
     # Check if file exists
     if not workflow_file.exists():
@@ -505,6 +588,12 @@ def run(
         # CLI flag overrides config
         sandbox_config_dict["enabled"] = sandbox
     sandbox_config = SandboxConfig(**sandbox_config_dict)
+
+    # Pass logging preferences through to the sandbox container so container stderr matches CLI UX.
+    sandbox_config.env.setdefault(
+        "TACTUS_LOG_LEVEL", str(log_level or ("debug" if verbose else "info"))
+    )
+    sandbox_config.env.setdefault("TACTUS_LOG_FORMAT", str(log_format))
 
     # Check Docker availability
     docker_available, docker_reason = is_docker_available()

--- a/tactus/core/config_manager.py
+++ b/tactus/core/config_manager.py
@@ -98,7 +98,7 @@ class ConfigManager:
             sidecar_config = self._load_yaml_file(sidecar_path)
             if sidecar_config:
                 configs.append(("sidecar", sidecar_config))
-                logger.info(f"Loaded sidecar config: {sidecar_path}")
+                logger.debug(f"Loaded sidecar config: {sidecar_path}")
 
         # Store for debugging
         self.loaded_configs = configs
@@ -106,7 +106,7 @@ class ConfigManager:
         # Merge all configs (later configs override earlier ones)
         merged = self._merge_configs([c[1] for c in configs])
 
-        logger.info(f"Merged configuration from {len(configs)} source(s)")
+        logger.debug(f"Merged configuration from {len(configs)} source(s)")
         return merged
 
     def _find_sidecar_config(self, tac_path: Path) -> Optional[Path]:

--- a/tactus/core/dsl_stubs.py
+++ b/tactus/core/dsl_stubs.py
@@ -915,43 +915,49 @@ def create_dsl_stubs(
             if not isinstance(mock_config, dict):
                 continue
 
-            # Check if this is an agent mock (has tool_calls key)
-            if "tool_calls" in mock_config:
-                # Agent mock - specifies what tool calls the agent should simulate
+            # Tool mocks use explicit keys.
+            tool_mock_keys = {"returns", "temporal", "conditional", "error"}
+            if any(k in mock_config for k in tool_mock_keys):
+                # Convert DSL syntax to MockConfig format
+                processed_config = {}
+
+                # Static mocking with 'returns' key
+                if "returns" in mock_config:
+                    processed_config["output"] = mock_config["returns"]
+
+                # Temporal mocking
+                elif "temporal" in mock_config:
+                    processed_config["temporal"] = mock_config["temporal"]
+
+                # Conditional mocking
+                elif "conditional" in mock_config:
+                    # Convert DSL conditional format to MockManager format
+                    conditionals = []
+                    for cond in mock_config["conditional"]:
+                        if isinstance(cond, dict) and "when" in cond and "returns" in cond:
+                            conditionals.append({"when": cond["when"], "return": cond["returns"]})
+                    processed_config["conditional_mocks"] = conditionals
+
+                # Error simulation
+                elif "error" in mock_config:
+                    processed_config["error"] = mock_config["error"]
+
+                # Register the tool mock configuration
+                builder.register_mock(name, processed_config)
+                continue
+
+            # Agent mocks can be message-only, tool_calls-only, or both.
+            if any(k in mock_config for k in ("tool_calls", "message", "data")):
                 agent_config = {
                     "tool_calls": mock_config.get("tool_calls", []),
                     "message": mock_config.get("message", ""),
+                    "data": mock_config.get("data"),
                 }
                 builder.register_agent_mock(name, agent_config)
                 continue
 
-            # Otherwise, it's a tool mock
-            # Convert DSL syntax to MockConfig format
-            processed_config = {}
-
-            # Static mocking with 'returns' key
-            if "returns" in mock_config:
-                processed_config["output"] = mock_config["returns"]
-
-            # Temporal mocking
-            elif "temporal" in mock_config:
-                processed_config["temporal"] = mock_config["temporal"]
-
-            # Conditional mocking
-            elif "conditional" in mock_config:
-                # Convert DSL conditional format to MockManager format
-                conditionals = []
-                for cond in mock_config["conditional"]:
-                    if isinstance(cond, dict) and "when" in cond and "returns" in cond:
-                        conditionals.append({"when": cond["when"], "return": cond["returns"]})
-                processed_config["conditional_mocks"] = conditionals
-
-            # Error simulation
-            elif "error" in mock_config:
-                processed_config["error"] = mock_config["error"]
-
-            # Register the tool mock configuration
-            builder.register_mock(name, processed_config)
+            # Otherwise, ignore unknown mock config.
+            continue
 
     def _history(messages=None):
         """
@@ -1413,14 +1419,14 @@ def create_dsl_stubs(
 
         logger = logging.getLogger(__name__)
 
-        logger.info(
+        logger.debug(
             f"[AGENT_CREATION] Agent '{agent_name}': runtime_context={bool(_runtime_context)}, skip_agents={_runtime_context.get('skip_agents', 'N/A') if _runtime_context else 'N/A'}, has_log_handler={('log_handler' in _runtime_context) if _runtime_context else False}"
         )
 
         if _runtime_context and not _runtime_context.get("skip_agents", False):
             from tactus.dspy.agent import create_dspy_agent
 
-            logger.info(f"[AGENT_CREATION] Attempting immediate creation for agent '{agent_name}'")
+            logger.debug(f"[AGENT_CREATION] Attempting immediate creation for agent '{agent_name}'")
 
             try:
                 # Create the actual agent primitive NOW
@@ -1450,7 +1456,7 @@ def create_dsl_stubs(
                 handle._set_primitive(
                     agent_primitive, execution_context=_runtime_context.get("execution_context")
                 )
-                logger.info(
+                logger.debug(
                     f"[AGENT_CREATION] Agent '{agent_name}' created immediately during declaration, has_log_handler={hasattr(agent_primitive, 'log_handler') and agent_primitive.log_handler is not None}"
                 )
 
@@ -1458,7 +1464,9 @@ def create_dsl_stubs(
                 if "_created_agents" not in _runtime_context:
                     _runtime_context["_created_agents"] = {}
                 _runtime_context["_created_agents"][agent_name] = agent_primitive
-                logger.info(f"[AGENT_CREATION] Stored agent '{agent_name}' in _created_agents dict")
+                logger.debug(
+                    f"[AGENT_CREATION] Stored agent '{agent_name}' in _created_agents dict"
+                )
 
             except Exception as e:
                 logger.error(
@@ -1567,14 +1575,14 @@ def create_dsl_stubs(
 
         logger = logging.getLogger(__name__)
 
-        logger.info(
+        logger.debug(
             f"[AGENT_CREATION] Agent '{temp_name}': runtime_context={bool(_runtime_context)}, skip_agents={_runtime_context.get('skip_agents', 'N/A') if _runtime_context else 'N/A'}, has_log_handler={('log_handler' in _runtime_context) if _runtime_context else False}"
         )
 
         if _runtime_context and not _runtime_context.get("skip_agents", False):
             from tactus.dspy.agent import create_dspy_agent
 
-            logger.info(f"[AGENT_CREATION] Attempting immediate creation for agent '{temp_name}'")
+            logger.debug(f"[AGENT_CREATION] Attempting immediate creation for agent '{temp_name}'")
 
             try:
                 # Create the actual agent primitive NOW
@@ -1593,7 +1601,7 @@ def create_dsl_stubs(
                 if "log_handler" in _runtime_context:
                     agent_config["log_handler"] = _runtime_context["log_handler"]
 
-                logger.info(
+                logger.debug(
                     f"[AGENT_CREATION] Creating agent immediately: name={temp_name}, has_log_handler={'log_handler' in agent_config}"
                 )
                 agent_primitive = create_dspy_agent(
@@ -1607,7 +1615,7 @@ def create_dsl_stubs(
                 handle._set_primitive(
                     agent_primitive, execution_context=_runtime_context.get("execution_context")
                 )
-                logger.info(
+                logger.debug(
                     f"[AGENT_CREATION] Agent '{temp_name}' created immediately during declaration, has_log_handler={hasattr(agent_primitive, 'log_handler') and agent_primitive.log_handler is not None}"
                 )
 
@@ -1615,7 +1623,7 @@ def create_dsl_stubs(
                 if "_created_agents" not in _runtime_context:
                     _runtime_context["_created_agents"] = {}
                 _runtime_context["_created_agents"][temp_name] = agent_primitive
-                logger.info(f"[AGENT_CREATION] Stored agent '{temp_name}' in _created_agents dict")
+                logger.debug(f"[AGENT_CREATION] Stored agent '{temp_name}' in _created_agents dict")
 
             except Exception as e:
                 import traceback
@@ -1757,13 +1765,13 @@ def _make_binding_callback(
             old_name = value.name
             if old_name.startswith("_temp_agent_"):
                 # Rename the agent handle
-                callback_logger.info(f"[AGENT_RENAME] Renaming agent '{old_name}' to '{name}'")
+                callback_logger.debug(f"[AGENT_RENAME] Renaming agent '{old_name}' to '{name}'")
                 value.name = name
 
                 # Also rename the underlying primitive if it exists
                 if value._primitive is not None:
                     value._primitive.name = name
-                    callback_logger.info(
+                    callback_logger.debug(
                         f"[AGENT_RENAME] Updated primitive name: '{old_name}' -> '{name}'"
                     )
 
@@ -1777,7 +1785,7 @@ def _make_binding_callback(
                 if hasattr(builder, "registry") and old_name in builder.registry.agents:
                     agent_data = builder.registry.agents.pop(old_name)
                     builder.registry.agents[name] = agent_data
-                    callback_logger.info(
+                    callback_logger.debug(
                         f"[AGENT_RENAME] Re-registered agent '{name}' in builder.registry.agents"
                     )
 
@@ -1786,7 +1794,7 @@ def _make_binding_callback(
                     if old_name in runtime_context["_created_agents"]:
                         agent_primitive = runtime_context["_created_agents"].pop(old_name)
                         runtime_context["_created_agents"][name] = agent_primitive
-                        callback_logger.info(
+                        callback_logger.debug(
                             f"[AGENT_RENAME] Updated _created_agents dict: '{old_name}' -> '{name}'"
                         )
 

--- a/tactus/core/execution_context.py
+++ b/tactus/core/execution_context.py
@@ -187,7 +187,7 @@ class BaseExecutionContext(ExecutionContext):
         On replay, returns cached result from execution log.
         On first execution, runs fn(), records in log, and returns result.
         """
-        logger.info(
+        logger.debug(
             f"[CHECKPOINT] checkpoint() called, type={checkpoint_type}, has_log_handler={self.log_handler is not None}"
         )
         current_position = self.metadata.replay_index
@@ -259,7 +259,7 @@ class BaseExecutionContext(ExecutionContext):
                     source_location=source_location,
                     procedure_id=self.procedure_id,
                 )
-                logger.info(
+                logger.debug(
                     f"[CHECKPOINT] Emitting CheckpointCreatedEvent: position={current_position}, type={checkpoint_type}, duration_ms={duration_ms}"
                 )
                 self.log_handler.log(event)

--- a/tactus/core/lua_sandbox.py
+++ b/tactus/core/lua_sandbox.py
@@ -73,7 +73,7 @@ class LuaSandbox:
         # Setup safe globals
         self._setup_safe_globals()
 
-        logger.info("Lua sandbox initialized successfully")
+        logger.debug("Lua sandbox initialized successfully")
 
     def _attribute_filter(self, obj, attr_name, is_setting):
         """
@@ -274,7 +274,7 @@ class LuaSandbox:
             self.lua.globals()["math"] = safe_math_table
             self.lua.globals()["os"] = safe_os_table
 
-            logger.info("Installed safe math and os libraries with determinism checking")
+            logger.debug("Installed safe math and os libraries with determinism checking")
             return  # Skip default os.date setup below
 
         # Add safe subset of os module (only date function for timestamps)

--- a/tactus/docker/Dockerfile
+++ b/tactus/docker/Dockerfile
@@ -36,6 +36,10 @@ COPY pyproject.toml ./
 COPY README.md ./
 COPY tactus/ ./tactus/
 
+# Ensure the non-root runtime user can read the codebase even if the host
+# working tree has restrictive permissions (e.g., umask 077).
+RUN chmod -R a+rX /app/tactus
+
 # Install Tactus and its dependencies
 RUN pip install --no-cache-dir -e .
 

--- a/tactus/dspy/agent.py
+++ b/tactus/dspy/agent.py
@@ -191,11 +191,19 @@ class DSPyAgentHandle:
             if response and hasattr(response, "_hidden_params"):
                 total_cost = response._hidden_params.get("response_cost")
 
-            if total_cost is None and response:
+            if total_cost is None and total_tokens > 0:
                 try:
-                    import litellm
+                    # We already have token counts, so compute cost from tokens to avoid relying
+                    # on provider-specific response object shapes.
+                    from litellm.cost_calculator import cost_per_token
 
-                    total_cost = litellm.completion_cost(completion_response=response)
+                    prompt_cost, completion_cost = cost_per_token(
+                        model=str(model) if model is not None else "",
+                        prompt_tokens=prompt_tokens,
+                        completion_tokens=completion_tokens,
+                        call_type="completion",
+                    )
+                    total_cost = float(prompt_cost) + float(completion_cost)
                 except Exception as e:
                     logger.warning(f"[COST] Agent '{self.name}': failed to calculate cost: {e}")
                     total_cost = 0.0
@@ -326,6 +334,7 @@ class DSPyAgentHandle:
 
         Streaming is enabled when:
         - log_handler is available (for emitting events)
+        - log_handler supports streaming events
         - disable_streaming is False
         - No structured output schema (streaming only works with plain text)
 
@@ -335,6 +344,14 @@ class DSPyAgentHandle:
         # Must have log_handler to emit streaming events
         if self.log_handler is None:
             logger.debug(f"[STREAMING] Agent '{self.name}': no log_handler, streaming disabled")
+            return False
+
+        # Allow log handlers to opt out of streaming (e.g., cost-only collectors)
+        supports_streaming = getattr(self.log_handler, "supports_streaming", True)
+        if not supports_streaming:
+            logger.debug(
+                f"[STREAMING] Agent '{self.name}': log_handler supports_streaming=False, streaming disabled"
+            )
             return False
 
         # Respect explicit disable flag
@@ -673,9 +690,7 @@ class DSPyAgentHandle:
             result = worker({message = "Process this task"})
             print(result.response)
         """
-        logger.info(
-            f"[CHECKPOINT] DSPyAgentHandle.__call__ invoked directly for agent '{self.name}' - THIS BYPASSES AgentHandle checkpoint logic!"
-        )
+        logger.debug(f"Agent '{self.name}' invoked via __call__()")
         inputs = inputs or {}
 
         # Handle string input as a convenience: Agent("message") -> Agent({message="message"})

--- a/tactus/primitives/handles.py
+++ b/tactus/primitives/handles.py
@@ -108,7 +108,7 @@ class AgentHandle:
             result = worker({message = "Process this task"})
             print(result.response)
         """
-        logger.info(
+        logger.debug(
             f"[CHECKPOINT] AgentHandle '{self.name}'.__call__ invoked, _primitive={self._primitive is not None}, _execution_context={self._execution_context is not None}"
         )
         if self._primitive is None:
@@ -121,7 +121,7 @@ class AgentHandle:
         converted_inputs = _convert_lua_table(inputs) if inputs is not None else None
 
         # If we have an execution context, checkpoint the agent call
-        logger.info(
+        logger.debug(
             f"[CHECKPOINT] AgentHandle '{self.name}' called, has_execution_context={self._execution_context is not None}"
         )
         if self._execution_context is not None:
@@ -146,7 +146,7 @@ class AgentHandle:
                 except Exception as e:
                     logger.debug(f"Could not capture source location: {e}")
 
-            logger.info(
+            logger.debug(
                 f"[CHECKPOINT] Creating checkpoint for agent '{self.name}', type=agent_turn, source_info={source_info}"
             )
             return self._execution_context.checkpoint(
@@ -170,7 +170,7 @@ class AgentHandle:
         """
         self._primitive = primitive
         self._execution_context = execution_context
-        logger.info(
+        logger.debug(
             f"[CHECKPOINT] AgentHandle '{self.name}' connected to primitive (checkpointing={'enabled' if execution_context else 'disabled'}, execution_context={execution_context})"
         )
 

--- a/tactus/sandbox/container_runner.py
+++ b/tactus/sandbox/container_runner.py
@@ -8,7 +8,9 @@ and collecting results via stdio communication.
 import asyncio
 import logging
 import os
+import re
 import shutil
+import sys
 import tempfile
 import time
 import uuid
@@ -24,6 +26,22 @@ from .protocol import (
 )
 
 logger = logging.getLogger(__name__)
+
+_CONTAINER_LOG_RE = re.compile(
+    r"^(?P<asctime>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}) "
+    r"\[(?P<level>[A-Z]+)\] "
+    r"(?P<logger>[^:]+): "
+    r"(?P<message>.*)$"
+)
+
+_LEVEL_MAP = {
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "WARNING": logging.WARNING,
+    "WARN": logging.WARNING,
+    "ERROR": logging.ERROR,
+    "CRITICAL": logging.CRITICAL,
+}
 
 
 class SandboxError(Exception):
@@ -158,6 +176,7 @@ class ContainerRunner:
         extra_env: Optional[Dict[str, str]] = None,
         execution_id: Optional[str] = None,
         callback_url: Optional[str] = None,
+        volume_base_dir: Optional[Path] = None,
     ) -> List[str]:
         """
         Build the docker run command.
@@ -218,7 +237,7 @@ class ContainerRunner:
 
         # Additional user-configured volumes
         for volume in self.config.volumes:
-            cmd.extend(["-v", volume])
+            cmd.extend(["-v", self._normalize_volume_spec(volume, base_dir=volume_base_dir)])
 
         # Pass through environment variables
         for var_name in self.PASSTHROUGH_ENV_VARS:
@@ -246,6 +265,42 @@ class ContainerRunner:
         cmd.append(self.config.image)
 
         return cmd
+
+    def _normalize_volume_spec(self, volume: str, base_dir: Optional[Path]) -> str:
+        """
+        Normalize a docker volume spec.
+
+        Docker only accepts absolute host paths for bind mounts. For convenience,
+        allow sidecar configs to use relative paths and normalize them here.
+
+        Expected formats:
+          - /abs/host:/container[:mode]
+          - ./rel/host:/container[:mode]
+          - ../rel/host:/container[:mode]
+          - volume_name:/container[:mode]  (left unchanged)
+        """
+        # Basic split: host:container[:mode]
+        parts = volume.split(":")
+        if len(parts) < 2:
+            return volume
+
+        host = parts[0]
+        container = parts[1]
+        mode = parts[2] if len(parts) > 2 else None
+
+        host_is_path = host.startswith(("/", "./", "../", "~"))
+        if not host_is_path:
+            # Named volume (or other special form) - leave unchanged
+            return volume
+
+        host_path = Path(host).expanduser()
+        if not host_path.is_absolute():
+            host_path = (base_dir or Path.cwd()) / host_path
+        host_path = host_path.resolve()
+
+        if mode:
+            return f"{host_path}:{container}:{mode}"
+        return f"{host_path}:{container}"
 
     async def run(
         self,
@@ -302,12 +357,22 @@ class ContainerRunner:
             # Get MCP servers path
             mcp_path = self.config.get_mcp_servers_path()
 
+            # Resolve relative bind-mount paths in sandbox.volumes relative to the procedure file
+            # when available (makes sidecar configs portable).
+            volume_base_dir = None
+            if source_file_path:
+                try:
+                    volume_base_dir = Path(source_file_path).resolve().parent
+                except Exception:
+                    volume_base_dir = None
+
             # Build docker command
             docker_cmd = self._build_docker_command(
                 working_dir=working_dir,
                 mcp_servers_path=mcp_path if mcp_path.exists() else None,
                 execution_id=execution_id,
                 callback_url=callback_url,
+                volume_base_dir=volume_base_dir,
             )
 
             logger.debug(f"Docker command: {' '.join(docker_cmd)}")
@@ -389,10 +454,7 @@ class ContainerRunner:
             stdout = stdout_data.decode("utf-8", errors="replace")
             stderr = stderr_data.decode("utf-8", errors="replace")
 
-            # Log stderr (container logs)
-            if stderr:
-                for line in stderr.strip().split("\n"):
-                    logger.info(f"[container] {line}")
+            self._handle_container_stderr(stderr)
 
             # Extract result from stdout
             result = extract_result_from_stdout(stdout)
@@ -436,6 +498,61 @@ class ContainerRunner:
             except Exception:
                 pass
             raise
+
+    def _handle_container_stderr(self, stderr: str) -> None:
+        """
+        Forward container stderr into the host log UX.
+
+        - raw: pass through container stderr as-is (CloudWatch-friendly)
+        - rich/terminal: parse container log lines and re-emit with host formatting
+        """
+        if not stderr:
+            return
+
+        fmt = str(self.config.env.get("TACTUS_LOG_FORMAT", "rich")).strip().lower()
+
+        # Raw mode: avoid double timestamps by forwarding container stderr directly.
+        if fmt == "raw":
+            sys.stderr.write(stderr)
+            sys.stderr.flush()
+            return
+
+        # Rich/terminal: parse our container log format and re-emit.
+        current: tuple[str, int, list[str]] | None = None  # (logger_name, levelno, lines)
+
+        def flush_current() -> None:
+            nonlocal current
+            if current is None:
+                return
+            logger_name, levelno, lines = current
+            message = "\n".join(lines).rstrip("\n")
+            logging.getLogger(logger_name).log(levelno, message)
+            current = None
+
+        for line in stderr.splitlines():
+            m = _CONTAINER_LOG_RE.match(line)
+            if m:
+                flush_current()
+                levelno = _LEVEL_MAP.get(m.group("level"), logging.INFO)
+                current = (m.group("logger"), levelno, [m.group("message")])
+                continue
+
+            # Continuation heuristic: keep multi-line LogEvent context attached.
+            if current is not None and (
+                line == ""
+                or line.startswith((" ", "\t"))
+                or line.startswith("Context:")
+                or line.startswith("{")
+                or line.startswith("[")
+            ):
+                current[2].append(line)
+                continue
+
+            # Otherwise treat as standalone stderr (warnings/tracebacks/etc).
+            flush_current()
+            logging.getLogger("container.stderr").warning(line)
+
+        flush_current()
 
     def run_sync(
         self,

--- a/tactus/sandbox/docker_manager.py
+++ b/tactus/sandbox/docker_manager.py
@@ -34,9 +34,12 @@ def calculate_source_hash(tactus_root: Path) -> str:
     # Key paths that affect sandbox behavior
     paths_to_hash = [
         tactus_root / "tactus" / "dspy",
+        tactus_root / "tactus" / "adapters",
         tactus_root / "tactus" / "core",
         tactus_root / "tactus" / "primitives",
         tactus_root / "tactus" / "sandbox",
+        tactus_root / "tactus" / "stdlib",
+        tactus_root / "tactus" / "docker",
         tactus_root / "pyproject.toml",  # Dependencies affect sandbox
     ]
 
@@ -50,12 +53,21 @@ def calculate_source_hash(tactus_root: Path) -> str:
             # Hash file contents
             hasher.update(path.read_bytes())
         elif path.is_dir():
-            # Hash all Python files in directory (recursively)
-            for py_file in sorted(path.rglob("*.py")):
+            # Hash directory files (recursively), skipping caches.
+            for file in sorted(path.rglob("*")):
+                if not file.is_file():
+                    continue
+                if "__pycache__" in file.parts:
+                    continue
+                if file.suffix == ".pyc":
+                    continue
+                if file.name == ".DS_Store":
+                    continue
+
                 # Hash relative path + contents for reproducibility
-                rel_path = str(py_file.relative_to(tactus_root))
+                rel_path = str(file.relative_to(tactus_root))
                 hasher.update(rel_path.encode())
-                hasher.update(py_file.read_bytes())
+                hasher.update(file.read_bytes())
 
     # Return short hash (16 chars is plenty for collision avoidance)
     return hasher.hexdigest()[:16]

--- a/tactus/sandbox/entrypoint.py
+++ b/tactus/sandbox/entrypoint.py
@@ -22,12 +22,34 @@ if TYPE_CHECKING:
     from tactus.sandbox.protocol import ExecutionResult
 
 # Configure logging to stderr (stdout is reserved for result)
+_LOG_LEVELS = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "warn": logging.WARNING,
+    "error": logging.ERROR,
+    "critical": logging.CRITICAL,
+}
+
+_log_level_str = os.environ.get("TACTUS_LOG_LEVEL", "info").strip().lower()
+_log_level = _LOG_LEVELS.get(_log_level_str, logging.INFO)
+
+# CloudWatch-friendly, one line per record.
+_log_fmt = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    level=_log_level,
+    format=_log_fmt,
     stream=sys.stderr,
 )
 logger = logging.getLogger(__name__)
+
+# Keep container stderr focused on procedure logs by default.
+# Use `TACTUS_LOG_LEVEL=debug` to include internal runtime logs.
+if _log_level > logging.DEBUG:
+    logging.getLogger("tactus.core").setLevel(logging.WARNING)
+    logging.getLogger("tactus.primitives").setLevel(logging.WARNING)
+    logging.getLogger("tactus.stdlib").setLevel(logging.WARNING)
 
 
 def read_request_from_stdin() -> Optional[Dict[str, Any]]:
@@ -81,6 +103,7 @@ async def execute_procedure(
     from tactus.core import TactusRuntime
     from tactus.adapters.memory import MemoryStorage
     from tactus.adapters.http_callback_log import HTTPCallbackLogHandler
+    from tactus.adapters.cost_collector_log import CostCollectorLogHandler
 
     # Create a unique procedure ID
     import uuid
@@ -93,6 +116,11 @@ async def execute_procedure(
         logger.info(
             f"[SANDBOX] Using HTTP callback log handler: {os.environ.get('TACTUS_CALLBACK_URL')}"
         )
+    else:
+        # Provide cost collection + checkpoint event handling even without IDE callbacks.
+        # This avoids misleading 0-cost summaries for sandbox runs, while keeping streaming off.
+        log_handler = CostCollectorLogHandler()
+        logger.info("[SANDBOX] No callback URL set; using CostCollectorLogHandler")
 
     # Create runtime with log handler for event streaming
     runtime = TactusRuntime(

--- a/tactus/stdlib/io/fs.py
+++ b/tactus/stdlib/io/fs.py
@@ -1,0 +1,154 @@
+"""
+tactus.io.fs - Filesystem helpers for Tactus.
+
+Provides safe directory listing and globbing, sandboxed to the procedure's base directory.
+
+Usage in .tac files:
+    local fs = require("tactus.io.fs")
+
+    -- List files in a directory
+    local entries = fs.list_dir("chapters")
+
+    -- Glob files (sorted by default)
+    local qmd_files = fs.glob("chapters/*.qmd")
+"""
+
+from __future__ import annotations
+
+import glob as _glob
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Get context (injected by loader)
+_ctx = getattr(sys.modules[__name__], "__tactus_context__", None)
+
+
+def _base_path() -> str:
+    if _ctx and getattr(_ctx, "base_path", None):
+        return str(_ctx.base_path)
+    return os.getcwd()
+
+
+def _validate_relative_path(path: str) -> None:
+    # Keep semantics consistent with other stdlib IO modules:
+    # - no absolute paths
+    # - no traversal segments
+    p = Path(path)
+    if p.is_absolute():
+        raise PermissionError(f"Absolute paths not allowed: {path}")
+    if any(part == ".." for part in p.parts):
+        raise PermissionError(f"Path traversal not allowed: {path}")
+
+
+def list_dir(dirpath: str, options: Optional[Dict[str, Any]] = None) -> List[str]:
+    """
+    List entries in a directory.
+
+    Args:
+        dirpath: Directory path (relative to working directory)
+        options:
+          - files_only: bool (default True) - include only files
+          - dirs_only: bool (default False) - include only directories
+          - sort: bool (default True) - sort results
+
+    Returns:
+        List of entry paths (relative to working directory)
+    """
+    options = options or {}
+    files_only = bool(options.get("files_only", True))
+    dirs_only = bool(options.get("dirs_only", False))
+    sort = bool(options.get("sort", True))
+
+    _validate_relative_path(dirpath)
+
+    base = os.path.realpath(_base_path())
+    abs_dir = os.path.realpath(os.path.join(base, dirpath))
+
+    # Ensure the directory itself is within base path (symlink-safe via realpath)
+    if abs_dir != base and not abs_dir.startswith(base + os.sep):
+        raise PermissionError(f"Access denied: path outside working directory: {dirpath}")
+
+    if not os.path.isdir(abs_dir):
+        raise FileNotFoundError(f"Directory not found: {dirpath}")
+
+    entries: List[str] = []
+    for name in os.listdir(abs_dir):
+        abs_child = os.path.realpath(os.path.join(abs_dir, name))
+        if abs_child != base and not abs_child.startswith(base + os.sep):
+            # Skip symlink escapes
+            continue
+
+        is_dir = os.path.isdir(abs_child)
+        is_file = os.path.isfile(abs_child)
+
+        if dirs_only and not is_dir:
+            continue
+        if files_only and not is_file:
+            continue
+
+        rel = os.path.relpath(abs_child, base).replace("\\", "/")
+        entries.append(rel)
+
+    if sort:
+        entries.sort()
+
+    return entries
+
+
+def glob(pattern: str, options: Optional[Dict[str, Any]] = None) -> List[str]:
+    """
+    Glob files within the working directory.
+
+    Args:
+        pattern: Glob pattern (relative to working directory), e.g. "chapters/*.qmd"
+        options:
+          - recursive: bool (default False) - enable ** patterns
+          - files_only: bool (default True) - include only files
+          - dirs_only: bool (default False) - include only directories
+          - sort: bool (default True) - sort results
+
+    Returns:
+        List of matched paths (relative to working directory)
+    """
+    options = options or {}
+    recursive = bool(options.get("recursive", False))
+    files_only = bool(options.get("files_only", True))
+    dirs_only = bool(options.get("dirs_only", False))
+    sort = bool(options.get("sort", True))
+
+    _validate_relative_path(pattern)
+
+    base = os.path.realpath(_base_path())
+    abs_pattern = os.path.realpath(os.path.join(base, pattern))
+
+    # Ensure the pattern root is within base path (symlink-safe via realpath)
+    if abs_pattern != base and not abs_pattern.startswith(base + os.sep):
+        raise PermissionError(f"Access denied: path outside working directory: {pattern}")
+
+    matches: List[str] = []
+    for match in _glob.glob(abs_pattern, recursive=recursive):
+        abs_match = os.path.realpath(match)
+        if abs_match != base and not abs_match.startswith(base + os.sep):
+            # Skip symlink escapes
+            continue
+
+        is_dir = os.path.isdir(abs_match)
+        is_file = os.path.isfile(abs_match)
+
+        if dirs_only and not is_dir:
+            continue
+        if files_only and not is_file:
+            continue
+
+        rel = os.path.relpath(abs_match, base).replace("\\", "/")
+        matches.append(rel)
+
+    if sort:
+        matches.sort()
+
+    return matches
+
+
+__tactus_exports__ = ["list_dir", "glob"]

--- a/tactus/stdlib/loader.py
+++ b/tactus/stdlib/loader.py
@@ -134,7 +134,7 @@ class StdlibModuleLoader:
         # Cache
         self.loaded_modules[module_name] = lua_table
 
-        logger.info(f"Loaded stdlib Python module: {module_name}")
+        logger.debug(f"Loaded stdlib Python module: {module_name}")
         return lua_table
 
     def _get_module_exports(self, module) -> Dict[str, Callable]:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -119,3 +119,76 @@ Procedure {
         app, ["run", str(workflow_file), "--param", "name=TestUser", "--no-sandbox"]
     )
     assert result.exit_code == 0
+
+
+def test_cli_run_help_includes_logging_options(cli_runner):
+    """Test that run --help documents log-level and log-format options."""
+    result = cli_runner.invoke(app, ["run", "--help"])
+    assert result.exit_code == 0
+    assert "--log-level" in result.stdout
+    assert "--log-format" in result.stdout
+
+
+def test_cli_run_accepts_log_level_and_format(cli_runner, tmp_path):
+    """Test that run accepts --log-level/--log-format (no-sandbox)."""
+    workflow_file = tmp_path / "logging_flags.tac"
+    workflow_file.write_text(
+        """
+Procedure {
+  input = {},
+  output = { ok = field.boolean{required = true} },
+  function(input)
+    Log.debug("debug message")
+    Log.info("info message")
+    Log.warn("warn message")
+    return { ok = true }
+  end
+}
+"""
+    )
+
+    result = cli_runner.invoke(
+        app,
+        [
+            "run",
+            str(workflow_file),
+            "--no-sandbox",
+            "--log-level",
+            "info",
+            "--log-format",
+            "terminal",
+        ],
+    )
+    assert result.exit_code == 0
+
+
+def test_cli_run_invalid_log_level(cli_runner, example_workflow_file):
+    """Test that run rejects invalid --log-level values."""
+    result = cli_runner.invoke(
+        app,
+        [
+            "run",
+            str(example_workflow_file),
+            "--no-sandbox",
+            "--log-level",
+            "nope",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "log-level" in result.stdout.lower()
+
+
+def test_cli_run_invalid_log_format(cli_runner, example_workflow_file):
+    """Test that run rejects invalid --log-format values."""
+    result = cli_runner.invoke(
+        app,
+        [
+            "run",
+            str(example_workflow_file),
+            "--no-sandbox",
+            "--log-format",
+            "nope",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "log-format" in result.stdout.lower()


### PR DESCRIPTION
Adds `--log-level` and `--log-format` to `tactus run` (`rich`/`terminal`/`raw`) and forwards log prefs into the sandbox container for consistent output.

Also adds `tactus.io.fs` (`glob`/`list_dir`) for safe file enumeration and documents it in `SPECIFICATION.md`.

Includes CLI tests + README docs.