### PR TITLE
fix: disallow curried Tool syntax

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -81,6 +81,14 @@ Call a host tool from Lua:
 local result = Host.call("host.ping", {value = 1})
 ```
 
+Or wrap it as a normal `Tool` using a broker tool source:
+
+```lua
+host_ping = Tool { use = "broker.host.ping" } -- calls broker allowlisted tool: host.ping
+
+local result = host_ping({value = 1})
+```
+
 ### Default Allowlist (Phase 1B)
 
 The default broker allowlist intentionally starts small:

--- a/examples/60-tool-sources.tac
+++ b/examples/60-tool-sources.tac
@@ -9,8 +9,8 @@ local log = require("tactus.tools.log")
 -- http = require("tactus.http")
 
 -- 2. CLI Tool Wrapper (wraps git command)
--- Tool sources (e.g., `use = "cli.git"`) are not yet supported in the Lua DSL Tool {}
--- constructor. This example focuses on agent/toolset usage patterns.
+-- Tool sources (e.g., `use = "cli.git"`) are supported, but they require the
+-- underlying command to exist in the runtime environment.
 -- git_status = Tool { use = "cli.git", description = "Get git repository status" }
 
 -- 3. Plugin Tool (would need to be implemented)

--- a/examples/67-host-tool-source.tac
+++ b/examples/67-host-tool-source.tac
@@ -1,0 +1,41 @@
+--[[
+Example: Brokered Host Tool Source
+
+Demonstrates wrapping an allowlisted broker host tool as a normal `Tool` and
+calling it directly from Lua (no agent required).
+
+To run (requires sandbox/broker):
+  tactus sandbox rebuild --force
+  tactus run examples/67-host-tool-source.tac --sandbox --verbose
+]]--
+
+host_ping = Tool {
+    use = "broker.host.ping",
+    description = "Ping the broker allowlisted host tool (host.ping)"
+}
+
+Procedure {
+    output = {
+        ok = field.boolean{required = true},
+        echo = field.object{required = true},
+    },
+    function(input)
+        local result = host_ping({value = 1})
+        return {
+            ok = result.ok,
+            echo = result.echo,
+        }
+    end
+}
+
+Specifications([[
+Feature: Brokered Host Tool Source
+  Wrap and call an allowlisted broker tool from Lua
+
+  Scenario: Ping succeeds
+    Given the procedure has started
+    When the procedure runs
+    Then the procedure should complete successfully
+    And the output ok should be True
+]])
+

--- a/tactus/core/dsl_stubs.py
+++ b/tactus/core/dsl_stubs.py
@@ -1260,15 +1260,110 @@ def create_dsl_stubs(
         if handler_fn is None and isinstance(config_dict, dict):
             handler_fn = config_dict.pop("handler", None)
 
-        if handler_fn is None:
+        # Tool sources: allow `use = "..."` (or legacy/internal `source = "..."`) in lieu of a handler.
+        source = None
+        if isinstance(config_dict, dict):
+            source = config_dict.pop("use", None)
+            if source is not None:
+                if "source" in config_dict:
+                    raise TypeError(f"Tool '{tool_name}' cannot specify both 'use' and 'source'")
+                config_dict["source"] = source
+            else:
+                source = config_dict.get("source")
+
+        if handler_fn is not None and isinstance(source, str) and source.strip():
             raise TypeError(
-                f"Tool '{tool_name}' requires a function. "
-                "Use: multiply = Tool {{ function(args) ... end }}"
+                f"Tool '{tool_name}' cannot specify both a function and 'use = \"...\"'"
             )
+
+        is_source_tool = handler_fn is None and isinstance(source, str) and bool(source.strip())
+
+        if handler_fn is None and not is_source_tool:
+            raise TypeError(
+                f"Tool '{tool_name}' requires either a function or 'use = \"...\"'. "
+                'Example: my_tool = Tool { use = "broker.host.ping" }'
+            )
+
+        if is_source_tool:
+            source_str = source.strip()
+
+            def source_tool_handler(args):
+                import asyncio
+                import threading
+
+                # Resolve at call time so runtime toolsets are available.
+                if tool_primitive is None:
+                    raise RuntimeError(
+                        f"Tool '{tool_name}' is not available (tool primitive missing)"
+                    )
+
+                runtime = getattr(tool_primitive, "_runtime", None)
+                if runtime is None:
+                    raise RuntimeError(
+                        f"Tool '{tool_name}' is not available (runtime not connected)"
+                    )
+
+                toolset = runtime.toolset_registry.get(tool_name)
+                if toolset is None:
+                    raise RuntimeError(
+                        f"Tool '{tool_name}' not resolved from source '{source_str}'"
+                    )
+
+                tool_fn = tool_primitive._extract_tool_function(toolset, tool_name)
+
+                # Support both tool_fn(**kwargs) and tool_fn(args_dict) styles.
+                # Prefer kwargs (pydantic-ai Tool functions) then fall back to dict.
+                if hasattr(args, "items"):
+                    args_dict = lua_table_to_dict(args)
+                else:
+                    args_dict = args or {}
+                if not isinstance(args_dict, dict):
+                    raise TypeError(f"Tool '{tool_name}' args must be an object/table")
+
+                if asyncio.iscoroutinefunction(tool_fn):
+
+                    def _run_coro(coro):
+                        try:
+                            asyncio.get_running_loop()
+                        except RuntimeError:
+                            return asyncio.run(coro)
+
+                        result_container = {"value": None, "exception": None}
+
+                        def run_in_thread():
+                            try:
+                                result_container["value"] = asyncio.run(coro)
+                            except Exception as e:
+                                result_container["exception"] = e
+
+                        thread = threading.Thread(target=run_in_thread)
+                        thread.start()
+                        thread.join()
+
+                        if result_container["exception"] is not None:
+                            raise result_container["exception"]
+                        return result_container["value"]
+
+                    try:
+                        return _run_coro(tool_fn(**args_dict))
+                    except TypeError:
+                        return _run_coro(tool_fn(args_dict))
+
+                try:
+                    return tool_fn(**args_dict)
+                except TypeError:
+                    return tool_fn(args_dict)
+
+            handler_fn = source_tool_handler
 
         # Register tool with provided name
         builder.register_tool(tool_name, config_dict, handler_fn)
-        handle = ToolHandle(tool_name, handler_fn, tool_primitive)
+        handle = ToolHandle(
+            tool_name,
+            handler_fn,
+            tool_primitive,
+            record_calls=not is_source_tool,
+        )
 
         # Store in registry
         _tool_registry[tool_name] = handle
@@ -1294,21 +1389,18 @@ def create_dsl_stubs(
         The name is captured via assignment interception.
 
         Args:
-            name_or_config: Either a string name (curried) or configuration table
+            name_or_config: Configuration table
 
         Returns:
-            ToolHandle that will be assigned to variable, or curried function
+            ToolHandle that will be assigned to a variable (or returned directly)
         """
         from tactus.primitives.tool_handle import ToolHandle
 
-        # Handle curried syntax: Tool "name" returns a function that accepts config
         if isinstance(name_or_config, str):
-            tool_name = name_or_config
-
-            def accept_config(config):
-                return _process_tool_config(tool_name, config)
-
-            return accept_config
+            raise TypeError(
+                "Curried Tool syntax is not supported. Use assignment syntax: my_tool = Tool { ... }, "
+                'or provide an explicit name in the config: Tool { name = "my_tool", ... }.'
+            )
 
         # Handle direct config syntax: multiply = Tool { ... }
         config = name_or_config
@@ -1341,22 +1433,130 @@ def create_dsl_stubs(
         if handler_fn is None and isinstance(config_dict, dict):
             handler_fn = config_dict.pop("handler", None)
 
-        if handler_fn is None:
+        # Tool sources: allow `use = "..."` (or legacy/internal `source = "..."`) in lieu of a handler.
+        source = None
+        if isinstance(config_dict, dict):
+            source = config_dict.pop("use", None)
+            if source is not None:
+                if "source" in config_dict:
+                    raise TypeError("Tool cannot specify both 'use' and 'source'")
+                config_dict["source"] = source
+            else:
+                source = config_dict.get("source")
+
+        if handler_fn is not None and isinstance(source, str) and source.strip():
+            raise TypeError("Tool cannot specify both a function and 'use = \"...\"'")
+
+        is_source_tool = handler_fn is None and isinstance(source, str) and bool(source.strip())
+
+        if handler_fn is None and not is_source_tool:
             raise TypeError(
-                "Tool requires a function. Use: multiply = Tool { function(args) ... end }"
+                "Tool requires either a function or 'use = \"...\"'. "
+                'Example: my_tool = Tool { use = "broker.host.ping" }'
             )
+
+        # Optional explicit tool name (primarily for `return Tool { ... }` cases).
+        explicit_name = None
+        if isinstance(config_dict, dict):
+            explicit_name = config_dict.pop("name", None)
+            if explicit_name is not None and not isinstance(explicit_name, str):
+                raise TypeError("Tool 'name' must be a string")
+            if isinstance(explicit_name, str) and not explicit_name.strip():
+                raise TypeError("Tool 'name' cannot be empty")
 
         # Generate a temporary name - will be replaced when assigned
         import uuid
 
-        temp_name = f"_temp_tool_{uuid.uuid4().hex[:8]}"
+        temp_name = (
+            explicit_name.strip()
+            if isinstance(explicit_name, str)
+            else f"_temp_tool_{uuid.uuid4().hex[:8]}"
+        )
+
+        if is_source_tool:
+            import asyncio
+            import threading
+
+            source_str = source.strip()
+            handle_ref = {"handle": None}
+
+            def source_tool_handler(args):
+                # Resolve at call time so runtime toolsets are available.
+                if tool_primitive is None:
+                    raise RuntimeError("Tool not available (tool primitive missing)")
+
+                runtime = getattr(tool_primitive, "_runtime", None)
+                if runtime is None:
+                    raise RuntimeError("Tool not available (runtime not connected)")
+
+                resolved_name = handle_ref["handle"].name if handle_ref["handle"] else temp_name
+                toolset = runtime.toolset_registry.get(resolved_name)
+                if toolset is None:
+                    raise RuntimeError(
+                        f"Tool '{resolved_name}' not resolved from source '{source_str}'"
+                    )
+
+                tool_fn = tool_primitive._extract_tool_function(toolset, resolved_name)
+
+                # Support both tool_fn(**kwargs) and tool_fn(args_dict) styles.
+                # Prefer kwargs (pydantic-ai Tool functions) then fall back to dict.
+                if hasattr(args, "items"):
+                    args_dict = lua_table_to_dict(args)
+                else:
+                    args_dict = args or {}
+                if not isinstance(args_dict, dict):
+                    raise TypeError("Tool args must be an object/table")
+
+                if asyncio.iscoroutinefunction(tool_fn):
+
+                    def _run_coro(coro):
+                        try:
+                            asyncio.get_running_loop()
+                        except RuntimeError:
+                            return asyncio.run(coro)
+
+                        result_container = {"value": None, "exception": None}
+
+                        def run_in_thread():
+                            try:
+                                result_container["value"] = asyncio.run(coro)
+                            except Exception as e:
+                                result_container["exception"] = e
+
+                        thread = threading.Thread(target=run_in_thread)
+                        thread.start()
+                        thread.join()
+
+                        if result_container["exception"] is not None:
+                            raise result_container["exception"]
+                        return result_container["value"]
+
+                    try:
+                        return _run_coro(tool_fn(**args_dict))
+                    except TypeError:
+                        return _run_coro(tool_fn(args_dict))
+
+                try:
+                    return tool_fn(**args_dict)
+                except TypeError:
+                    return tool_fn(args_dict)
+
+            handler_fn = source_tool_handler
 
         # Register tool
         builder.register_tool(temp_name, config_dict, handler_fn)
-        handle = ToolHandle(temp_name, handler_fn, tool_primitive)
+        handle = ToolHandle(
+            temp_name,
+            handler_fn,
+            tool_primitive,
+            record_calls=not is_source_tool,
+        )
 
         # Store in registry with temp name
         _tool_registry[temp_name] = handle
+
+        if is_source_tool:
+            handle_ref["handle"] = handle
 
         return handle
 
@@ -1760,6 +1960,11 @@ def _make_binding_callback(
                     callback_logger.debug(
                         f"Re-registered tool '{name}' in builder.registry.lua_tools"
                     )
+            elif old_name != name:
+                raise RuntimeError(
+                    f"Tool name mismatch: assigned to '{name}' but tool is named '{old_name}'. "
+                    "Remove the Tool config 'name' field or make it match the assigned variable."
+                )
 
         # Check if this is an AgentHandle with a temp name
         if isinstance(value, AgentHandle):

--- a/tactus/core/runtime.py
+++ b/tactus/core/runtime.py
@@ -1199,6 +1199,54 @@ class TactusRuntime:
                 logger.error(f"Failed to create CLI tool wrapper '{source}': {e}", exc_info=True)
                 return None
 
+        # Handle broker host tools (broker.*)
+        elif source.startswith("broker."):
+            broker_tool = source[7:]  # Remove "broker." prefix
+            if not broker_tool:
+                logger.error(
+                    f"Invalid broker tool source for '{tool_name}': {source} (expected broker.<tool>)"
+                )
+                return None
+
+            try:
+                from pydantic_ai import Tool
+                from pydantic_ai.toolsets import FunctionToolset
+
+                tool_primitive = self.tool_primitive
+                host_primitive = self.host_primitive
+                mock_manager = self.mock_manager
+
+                def broker_tool_wrapper(**kwargs: Any):
+                    if mock_manager:
+                        mock_result = mock_manager.get_mock_response(tool_name, kwargs)
+                        if mock_result is not None:
+                            if tool_primitive:
+                                tool_primitive.record_call(tool_name, kwargs, mock_result)
+                            mock_manager.record_call(tool_name, kwargs, mock_result)
+                            return mock_result
+
+                    result = host_primitive.call(broker_tool, kwargs)
+
+                    if tool_primitive:
+                        tool_primitive.record_call(tool_name, kwargs, result)
+                    if mock_manager:
+                        mock_manager.record_call(tool_name, kwargs, result)
+
+                    return result
+
+                broker_tool_wrapper.__name__ = tool_name
+                broker_tool_wrapper.__doc__ = f"Brokered host tool: {broker_tool}"
+
+                wrapped_tool = Tool(broker_tool_wrapper, name=tool_name)
+                return FunctionToolset(tools=[wrapped_tool])
+
+            except Exception as e:
+                logger.error(
+                    f"Failed to create broker tool '{tool_name}' from source '{source}': {e}",
+                    exc_info=True,
+                )
+                return None
+
         else:
             logger.error(f"Unknown tool source format: {source}")
             return None

--- a/tactus/primitives/tool_handle.py
+++ b/tactus/primitives/tool_handle.py
@@ -33,6 +33,7 @@ class ToolHandle:
         impl_fn: Callable,
         tool_primitive: Optional["ToolPrimitive"] = None,
         is_async: bool = False,
+        record_calls: bool = True,
     ):
         """
         Initialize a tool handle.
@@ -47,6 +48,7 @@ class ToolHandle:
         self.impl_fn = impl_fn
         self.tool_primitive = tool_primitive
         self.is_async = is_async
+        self.record_calls = record_calls
 
         logger.debug(f"ToolHandle created for '{name}' (async={is_async})")
 
@@ -77,7 +79,7 @@ class ToolHandle:
                 result = self.impl_fn(args)
 
             # Record the call for tracking
-            if self.tool_primitive:
+            if self.tool_primitive and self.record_calls:
                 self.tool_primitive.record_call(self.name, args, result)
 
             logger.debug(f"ToolHandle.call('{self.name}') returned: {result}")

--- a/tactus/stdlib/tac/tactus/tools/done.tac
+++ b/tactus/stdlib/tac/tactus/tools/done.tac
@@ -16,9 +16,9 @@ Usage:
     end
 ]]--
 
--- Use named syntax so the tool has explicit name "done"
--- (required for mock mode where tool calls are recorded by name)
-return Tool "done" {
+-- Provide explicit name so the tool is recorded/mocked as "done"
+return Tool {
+    name = "done",
     description = "Signal task completion",
     input = {
         reason = field.string{required = false, description = "Reason for completion"}

--- a/tactus/validation/semantic_visitor.py
+++ b/tactus/validation/semantic_visitor.py
@@ -155,6 +155,23 @@ class TactusDSLVisitor(LuaParserVisitor):
                 elif func_name == "Tool":
                     # Extract config from Tool {...}
                     config = self._extract_single_table_arg(func_call)
+                    if (
+                        config
+                        and isinstance(config, dict)
+                        and isinstance(config.get("name"), str)
+                        and config.get("name") != var_name
+                    ):
+                        self.errors.append(
+                            ValidationMessage(
+                                level="error",
+                                message=(
+                                    f"Tool name mismatch: '{var_name} = Tool {{ name = \"{config.get('name')}\" }}'. "
+                                    f"Remove the 'name' field or set it to '{var_name}'."
+                                ),
+                                location=(self.current_line, self.current_col),
+                                declaration="Tool",
+                            )
+                        )
                     self.builder.register_tool(var_name, config if config else {}, None)
                 elif func_name == "Toolset":
                     # Extract config from Toolset {...}
@@ -508,28 +525,21 @@ class TactusDSLVisitor(LuaParserVisitor):
             if args and len(args) >= 1 and isinstance(args[0], dict):
                 self.builder.register_top_level_output(args[0])
         elif func_name == "Tool":  # CamelCase only
-            # Tool("name", {config}, function) - DEPRECATED curried syntax
-            # New syntax: tool_name = Tool { config, function }
-            if args and len(args) >= 1:  # Support curried syntax
-                # First arg must be name (string)
-                if isinstance(args[0], str):
-                    tool_name = args[0]
-                    # Check for special stdlib import syntax: Tool "name" { use = "..." }
-                    # This is still allowed for backwards compatibility
-                    config = args[1] if len(args) >= 2 and isinstance(args[1], dict) else {}
-                    if config.get("use"):
-                        # This is a stdlib import, still allowed
-                        self.builder.register_tool(tool_name, config, None)
-                    else:
-                        # This is deprecated curried syntax
-                        self.errors.append(
-                            ValidationMessage(
-                                level="error",
-                                message=f'Curried syntax Tool "{tool_name}" {{...}} is deprecated. Use assignment syntax: {tool_name} = Tool {{...}}',
-                                location=(self.current_line, self.current_col),
-                                declaration="Tool",
-                            )
-                        )
+            # Curried syntax (Tool "name" {...} / Tool("name", ...)) is not supported.
+            # Use assignment syntax: my_tool = Tool { ... }.
+            if args and len(args) >= 1 and isinstance(args[0], str):
+                tool_name = args[0]
+                self.errors.append(
+                    ValidationMessage(
+                        level="error",
+                        message=(
+                            f'Curried Tool syntax is not supported: Tool "{tool_name}" {{...}}. '
+                            f"Use assignment syntax: {tool_name} = Tool {{...}}."
+                        ),
+                        location=(self.current_line, self.current_col),
+                        declaration="Tool",
+                    )
+                )
         elif func_name == "Toolset":  # CamelCase only
             # Toolset("name", {config})
             # or new curried syntax: Toolset "name" { config }

--- a/tests/broker/test_broker_host_tool_source.py
+++ b/tests/broker/test_broker_host_tool_source.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from tactus.adapters.memory import MemoryStorage
+from tactus.core import TactusRuntime
+
+
+@pytest.mark.asyncio
+async def test_tool_use_broker_host_executes_allowlisted_host_tool(monkeypatch):
+    monkeypatch.delenv("TACTUS_BROKER_SOCKET", raising=False)
+
+    source = """
+host_ping = Tool {
+  use = "broker.host.ping"
+}
+
+Procedure {
+  output = {
+    ok = field.boolean{required = true},
+    echo = field.object{required = true},
+  },
+  function(_)
+    local result = host_ping({x = 1})
+    return { ok = result.ok, echo = result.echo }
+  end
+}
+"""
+
+    runtime = TactusRuntime(
+        procedure_id="test-broker-host-tool-source",
+        storage_backend=MemoryStorage(),
+        skip_agents=True,
+    )
+
+    result = await runtime.execute(source=source, context={}, format="lua")
+    assert result.get("success") is True
+    assert result.get("result") == {"ok": True, "echo": {"x": 1}}
+
+    assert runtime.tool_primitive.called("host_ping") is True

--- a/tests/validation/test_tool_curried_syntax_disallowed.py
+++ b/tests/validation/test_tool_curried_syntax_disallowed.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+
+from tactus.adapters.memory import MemoryStorage
+from tactus.core import TactusRuntime
+from tactus.validation import TactusValidator, ValidationMode
+
+
+def test_validator_rejects_curried_tool_syntax():
+    source = """
+Tool "my_tool" {
+  description = "Nope",
+  function(_)
+    return 1
+  end
+}
+
+Procedure {
+  output = { ok = field.boolean{required = true} },
+  function(_)
+    return { ok = true }
+  end
+}
+"""
+
+    result = TactusValidator().validate(source, mode=ValidationMode.FULL)
+    assert result.valid is False
+    assert any("Curried Tool syntax is not supported" in e.message for e in result.errors)
+
+
+@pytest.mark.asyncio
+async def test_runtime_errors_on_curried_tool_syntax():
+    source = """
+Tool "my_tool" {
+  description = "Nope",
+  function(_)
+    return 1
+  end
+}
+
+Procedure {
+  output = { ok = field.boolean{required = true} },
+  function(_)
+    return { ok = true }
+  end
+}
+"""
+
+    runtime = TactusRuntime(
+        procedure_id="test-curried-tool-disallowed",
+        storage_backend=MemoryStorage(),
+        skip_agents=True,
+    )
+
+    result = await runtime.execute(source=source, context={}, format="lua")
+    assert result.get("success") is False
+    assert "Curried Tool syntax is not supported" in result.get("error", "")


### PR DESCRIPTION
Summary:
- Disallow curried Tool syntax (Tool "name" { ... }) in runtime + validator.
- Add Tool { name = "..." } for explicit naming when returning tools (stdlib).
- Add broker host tool source example + tests.

Notes:
- Generated example artifacts were left untracked.