### PR TITLE
fix(classify): align ClassifyProcedure with structured LLM output contract

### DIFF
--- a/project/events/2026-04-15T21:08:02.088Z__4e957d5d-d117-4c9f-b714-7461056b1c6f.json
+++ b/project/events/2026-04-15T21:08:02.088Z__4e957d5d-d117-4c9f-b714-7461056b1c6f.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "4e957d5d-d117-4c9f-b714-7461056b1c6f",
+  "issue_id": "tcts-ec92c3e5-38a7-40c0-9c62-c6bccbd45b1c",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-15T21:08:02.088Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "ClassifyProcedure sometimes receives model output as {output: <text>} instead of {response: <text>}, causing output validation warnings, retries, and empty explanation fields despite successful classification. Implement a canonical extraction path in stdlib classifier to normalize structured model output and preserve explanation deterministically.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Fix ClassifyProcedure dropping explanation when model returns nested output payload"
+  }
+}

--- a/project/events/2026-04-15T21:08:06.025Z__ff2cf2ba-8126-407f-a356-04f566849542.json
+++ b/project/events/2026-04-15T21:08:06.025Z__ff2cf2ba-8126-407f-a356-04f566849542.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ff2cf2ba-8126-407f-a356-04f566849542",
+  "issue_id": "tcts-ec92c3e5-38a7-40c0-9c62-c6bccbd45b1c",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-15T21:08:06.025Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-15T21:08:06.034Z__83240d7e-4aab-452d-aa30-1ac60f66c9aa.json
+++ b/project/events/2026-04-15T21:08:06.034Z__83240d7e-4aab-452d-aa30-1ac60f66c9aa.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "83240d7e-4aab-452d-aa30-1ac60f66c9aa",
+  "issue_id": "tcts-ec92c3e5-38a7-40c0-9c62-c6bccbd45b1c",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-15T21:08:06.034Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "ab5df6eb-dc88-4712-a06f-7cf016fe846a"
+  }
+}

--- a/project/events/2026-04-15T21:15:23.573Z__10e08bc9-71dd-4910-91de-de167e8f8d84.json
+++ b/project/events/2026-04-15T21:15:23.573Z__10e08bc9-71dd-4910-91de-de167e8f8d84.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "10e08bc9-71dd-4910-91de-de167e8f8d84",
+  "issue_id": "tcts-ec92c3e5-38a7-40c0-9c62-c6bccbd45b1c",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-15T21:15:23.573Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "c0b8ac9c-e04d-4763-afff-29f811a14e96"
+  }
+}

--- a/project/events/2026-04-15T21:15:36.565Z__ead43ee2-0c66-4751-86ad-7073efa67628.json
+++ b/project/events/2026-04-15T21:15:36.565Z__ead43ee2-0c66-4751-86ad-7073efa67628.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ead43ee2-0c66-4751-86ad-7073efa67628",
+  "issue_id": "tcts-ec92c3e5-38a7-40c0-9c62-c6bccbd45b1c",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-15T21:15:36.565Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "60ff5cf9-8435-4dab-a0c4-ee9ada512fe7"
+  }
+}

--- a/project/issues/tcts-ec92c3e5-38a7-40c0-9c62-c6bccbd45b1c.json
+++ b/project/issues/tcts-ec92c3e5-38a7-40c0-9c62-c6bccbd45b1c.json
@@ -1,0 +1,37 @@
+{
+  "id": "tcts-ec92c3e5-38a7-40c0-9c62-c6bccbd45b1c",
+  "title": "Fix ClassifyProcedure dropping explanation when model returns nested output payload",
+  "description": "ClassifyProcedure sometimes receives model output as {output: <text>} instead of {response: <text>}, causing output validation warnings, retries, and empty explanation fields despite successful classification. Implement a canonical extraction path in stdlib classifier to normalize structured model output and preserve explanation deterministically.",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "ab5df6eb-dc88-4712-a06f-7cf016fe846a",
+      "author": "derek",
+      "text": "Started implementation. Will patch stdlib LLM classifier used by ClassifyProcedure to normalize model payload shape (response vs nested output) and ensure explanation is retained without changing score YAML APIs.",
+      "created_at": "2026-04-15T21:08:06.034177626Z"
+    },
+    {
+      "id": "c0b8ac9c-e04d-4763-afff-29f811a14e96",
+      "author": "derek",
+      "text": "Implementing strict contract fix: LLMModelBackend will return structured response payload matching stdlib schema; ClassifyProcedure explanation derived from response text. No dual-shape compatibility retained.",
+      "created_at": "2026-04-15T21:15:23.573445646Z"
+    },
+    {
+      "id": "60ff5cf9-8435-4dab-a0c4-ee9ada512fe7",
+      "author": "derek",
+      "text": "Applied strict contract changes in code: llm_backend now returns result={response=<text>} (not raw string), removed model-layer output auto-wrap compatibility path, and classify.llm now parses/derives explanation only from structured response.",
+      "created_at": "2026-04-15T21:15:36.564898838Z"
+    }
+  ],
+  "created_at": "2026-04-15T21:08:02.088587942Z",
+  "updated_at": "2026-04-15T21:15:36.564898838Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/tactus/backends/llm_backend.py
+++ b/tactus/backends/llm_backend.py
@@ -2,8 +2,7 @@
 LLM model backend for inference using language models.
 
 This backend uses an Agent internally to handle LLM interactions.
-It returns the raw completion text; callers (e.g. LLMClassifier) are
-responsible for parsing the class value out of the response.
+It returns structured output that matches the stdlib LLM model schema.
 """
 
 import json
@@ -99,7 +98,7 @@ class LLMModelBackend:
         Returns:
             Dict with prediction result, cost, and usage stats:
             {
-                "result": <parsed output>,
+                "result": {"response": <raw text>},
                 "cost": {"total": 0.001, "input": 0.0005, "output": 0.0005},
                 "usage": {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150}
             }
@@ -123,7 +122,7 @@ class LLMModelBackend:
         self._update_stats(agent_result)
 
         return {
-            "result": response_text,
+            "result": {"response": response_text},
             "cost": agent_result.cost_stats.model_dump(),
             "usage": agent_result.usage.model_dump(),
         }

--- a/tactus/stdlib/tac/tactus/text/classify/llm.tac
+++ b/tactus/stdlib/tac/tactus/text/classify/llm.tac
@@ -4,7 +4,7 @@
 -- - Retry logic for invalid responses
 -- - Multiple class support
 -- - Configurable confidence modes
--- - Response parsing with fallbacks
+-- - Response parsing from structured model output
 
 -- Load dependencies
 local base = require("tactus.text.classify.base")
@@ -122,6 +122,42 @@ function LLMClassifier:classify(input_text)
         return nil
     end
 
+    local function derive_explanation(raw_text, class_value)
+        if type(raw_text) ~= "string" then
+            return nil
+        end
+
+        local trimmed = raw_text:gsub("^%s+", ""):gsub("%s+$", "")
+        if trimmed == "" then
+            return nil
+        end
+
+        local lines = {}
+        for line in (trimmed .. "\n"):gmatch("([^\n]*)\n") do
+            local l = line:gsub("^%s+", ""):gsub("%s+$", "")
+            if l ~= "" then
+                table.insert(lines, l)
+            end
+        end
+
+        if #lines == 0 then
+            return nil
+        end
+
+        local last_line = lines[#lines]:gsub("[%*\"'`]", "")
+        local last_lower = last_line:lower()
+        local class_lower = class_value and tostring(class_value):lower() or nil
+        if class_lower ~= nil and last_lower == class_lower then
+            table.remove(lines, #lines)
+        end
+
+        if #lines == 0 then
+            return nil
+        end
+
+        return table.concat(lines, "\n")
+    end
+
     local last_output = nil
     for attempt = 1, self.max_retries + 1 do
         local result = self.model({text = input_text})
@@ -147,10 +183,6 @@ function LLMClassifier:classify(input_text)
                 value = self:parse_response(response_text)
             end
         end
-        if value == nil and type(output) == "string" then
-            value = self:parse_response(output)
-        end
-
         local canonical = nil
         if value ~= nil then
             canonical = valid_lower[tostring(value):lower()]
@@ -169,6 +201,10 @@ function LLMClassifier:classify(input_text)
                 response.confidence = 0.8
             end
             local expl = safe_get(output, "explanation")
+            if expl == nil then
+                local response_text = safe_get(output, "response")
+                expl = derive_explanation(response_text, canonical)
+            end
             if expl ~= nil then
                 response.explanation = expl
             end

--- a/tests/models/test_llm_backend.py
+++ b/tests/models/test_llm_backend.py
@@ -43,7 +43,7 @@ class TestLLMModelBackend:
 
         result = backend.predict_sync({"text": "I love this!"})
 
-        assert result["result"] == '{"label": "positive", "confidence": 0.95}'
+        assert result["result"] == {"response": '{"label": "positive", "confidence": 0.95}'}
         assert result["usage"]["prompt_tokens"] == 10
         assert result["usage"]["completion_tokens"] == 20
         assert result["cost"]["total_cost"] == 0.0003
@@ -68,10 +68,9 @@ class TestLLMModelBackend:
 
         result = backend.predict_sync({"text": "Great!"})
 
-        assert (
-            result["result"]
-            == '{"label": "positive"} This is because the text expresses happiness.'
-        )
+        assert result["result"] == {
+            "response": '{"label": "positive"} This is because the text expresses happiness.'
+        }
 
     def test_llm_backend_parse_direction_end(self):
         """Test LLM backend parses from end for chain-of-thought."""
@@ -93,10 +92,9 @@ class TestLLMModelBackend:
 
         result = backend.predict_sync({"text": "Amazing!"})
 
-        assert (
-            result["result"]
-            == 'Let me analyze this text. The sentiment is clearly positive. {"label": "positive"}'
-        )
+        assert result["result"] == {
+            "response": 'Let me analyze this text. The sentiment is clearly positive. {"label": "positive"}'
+        }
 
     def test_llm_backend_retry_on_invalid_response(self):
         """Test LLM backend returns raw response text without JSON retries/parsing."""
@@ -122,7 +120,7 @@ class TestLLMModelBackend:
 
         result = backend.predict_sync({"text": "Good"})
 
-        assert result["result"] == "Not JSON at all"
+        assert result["result"] == {"response": "Not JSON at all"}
         assert backend._agent.call_count == 1
 
     def test_llm_backend_fails_after_max_retries(self):
@@ -143,7 +141,7 @@ class TestLLMModelBackend:
         backend._agent = MagicMock(return_value=invalid_result)
         result = backend.predict_sync({"text": "Test"})
 
-        assert result["result"] == "Not JSON"
+        assert result["result"] == {"response": "Not JSON"}
         assert backend._agent.call_count == 1
 
     def test_llm_backend_cost_tracking(self):
@@ -290,7 +288,7 @@ class TestModelPrimitiveLLMBackend:
         backend._agent.assert_called_once()
         call_args = backend._agent.call_args[0][0]
         assert call_args["message"] == "Hello world"
-        assert result["result"] == '{"label": "positive"}'
+        assert result["result"] == {"response": '{"label": "positive"}'}
 
     def test_llm_backend_string_output_from_agent(self):
         """Test LLM backend when agent_result.output is string instead of dict."""
@@ -309,7 +307,7 @@ class TestModelPrimitiveLLMBackend:
 
         result = backend.predict_sync({"text": "Bad product"})
 
-        assert result["result"] == '{"label": "negative"}'
+        assert result["result"] == {"response": '{"label": "negative"}'}
 
     def test_llm_backend_parse_error_start_no_json(self):
         """Test LLM backend returns raw text when no JSON is present."""
@@ -329,7 +327,7 @@ class TestModelPrimitiveLLMBackend:
         backend._agent = MagicMock(return_value=mock_result)
         result = backend.predict_sync({"text": "Test"})
 
-        assert result["result"] == "This text does not start with JSON"
+        assert result["result"] == {"response": "This text does not start with JSON"}
 
     def test_llm_backend_parse_error_start_invalid_json(self):
         """Test LLM backend returns raw text when JSON-looking content is invalid."""
@@ -349,7 +347,7 @@ class TestModelPrimitiveLLMBackend:
         backend._agent = MagicMock(return_value=mock_result)
         result = backend.predict_sync({"text": "Test"})
 
-        assert result["result"] == "{invalid json here}"
+        assert result["result"] == {"response": "{invalid json here}"}
 
     def test_llm_backend_parse_error_end_no_json(self):
         """Test LLM backend returns raw text when response does not end with JSON."""
@@ -369,7 +367,7 @@ class TestModelPrimitiveLLMBackend:
         backend._agent = MagicMock(return_value=mock_result)
         result = backend.predict_sync({"text": "Test"})
 
-        assert result["result"] == "This text does not end with JSON at all"
+        assert result["result"] == {"response": "This text does not end with JSON at all"}
 
     def test_llm_backend_parse_error_end_invalid_json(self):
         """Test LLM backend returns raw text for invalid JSON fragments."""
@@ -389,7 +387,7 @@ class TestModelPrimitiveLLMBackend:
         backend._agent = MagicMock(return_value=mock_result)
         result = backend.predict_sync({"text": "Test"})
 
-        assert result["result"] == "Some reasoning text {invalid json here}"
+        assert result["result"] == {"response": "Some reasoning text {invalid json here}"}
 
     def test_llm_backend_agent_exception_propagates(self):
         """Test that exceptions from agent propagate correctly."""


### PR DESCRIPTION
**Summary**
- Updated `tactus/backends/llm_backend.py` so LLM model backend returns a structured payload in `result`: `{ "response": <text> }`.
- Updated `tactus/stdlib/tac/tactus/text/classify/llm.tac` to consume structured `response` output and derive explanation text from that payload.
- Updated `tests/models/test_llm_backend.py` to assert the new strict structured contract.
- Included Kanbus artifact files generated for this work session under `project/events/...` and `project/issues/tcts-ec92c3e5-38a7-40c0-9c62-c6bccbd45b1c.json`.

**Why**
- Fixes a contract mismatch where classifier execution received raw-string backend output while model schemas expected structured output.
- Prevents output-shape drift that led to validation warnings and unstable explanation handling in `ClassifyProcedure`.
- Keeps behavior explicit and deterministic now that no backward compatibility path is required for this rollout.

**Validation**
- `poetry run pytest tests/models/test_llm_backend.py -q`
- `poetry run python -m compileall tactus/backends/llm_backend.py`
- Result: `18 passed` for `tests/models/test_llm_backend.py`.

**Expected Outcome**
- `ClassifyProcedure` receives consistent structured model output and extracts explanation text reliably from `response`.
- LLM backend/model primitive behavior is aligned with stdlib expectations and corresponding tests.

**Kanbus / Task Tracking**
- `tcts-ec92c3`
