### PR TITLE
chore(pm): add final kanbus closure artifacts for tcts-ec92c3

### DIFF
--- a/project/events/2026-04-15T22:36:49.873Z__037012de-b80b-461a-9723-13bf2089e784.json
+++ b/project/events/2026-04-15T22:36:49.873Z__037012de-b80b-461a-9723-13bf2089e784.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "037012de-b80b-461a-9723-13bf2089e784",
+  "issue_id": "tcts-ec92c3e5-38a7-40c0-9c62-c6bccbd45b1c",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-15T22:36:49.873Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "fc170ee5-8cf9-405f-871d-6ca39a05ce25"
+  }
+}

--- a/project/events/2026-04-15T22:36:49.884Z__7c17c3a4-e436-4e88-96f4-9e2b5f91d50b.json
+++ b/project/events/2026-04-15T22:36:49.884Z__7c17c3a4-e436-4e88-96f4-9e2b5f91d50b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7c17c3a4-e436-4e88-96f4-9e2b5f91d50b",
+  "issue_id": "tcts-ec92c3e5-38a7-40c0-9c62-c6bccbd45b1c",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-15T22:36:49.884Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/tcts-ec92c3e5-38a7-40c0-9c62-c6bccbd45b1c.json
+++ b/project/issues/tcts-ec92c3e5-38a7-40c0-9c62-c6bccbd45b1c.json
@@ -3,7 +3,7 @@
   "title": "Fix ClassifyProcedure dropping explanation when model returns nested output payload",
   "description": "ClassifyProcedure sometimes receives model output as {output: <text>} instead of {response: <text>}, causing output validation warnings, retries, and empty explanation fields despite successful classification. Implement a canonical extraction path in stdlib classifier to normalize structured model output and preserve explanation deterministically.",
   "type": "bug",
-  "status": "in_progress",
+  "status": "closed",
   "priority": 1,
   "assignee": null,
   "creator": null,
@@ -28,10 +28,16 @@
       "author": "derek",
       "text": "Applied strict contract changes in code: llm_backend now returns result={response=<text>} (not raw string), removed model-layer output auto-wrap compatibility path, and classify.llm now parses/derives explanation only from structured response.",
       "created_at": "2026-04-15T21:15:36.564898838Z"
+    },
+    {
+      "id": "fc170ee5-8cf9-405f-871d-6ca39a05ce25",
+      "author": "derek",
+      "text": "Implemented and shipped via PR #55: strict structured LLM output contract for ClassifyProcedure path, explanation extraction aligned, tests updated/passing, PR opened to develop and release PR opened develop->main (#56).",
+      "created_at": "2026-04-15T22:36:49.873392479Z"
     }
   ],
   "created_at": "2026-04-15T21:08:02.088587942Z",
-  "updated_at": "2026-04-15T21:15:36.564898838Z",
-  "closed_at": null,
+  "updated_at": "2026-04-15T22:36:49.884032029Z",
+  "closed_at": "2026-04-15T22:36:49.884032029Z",
   "custom": {}
 }


### PR DESCRIPTION
**Summary**
- Add final Kanbus artifact event files generated when closing `tcts-ec92c3`.
- Update `project/issues/tcts-ec92c3e5-38a7-40c0-9c62-c6bccbd45b1c.json` with final close-out metadata.

**Why**
- Keeps project-management state in-repo consistent with completed Kanbus workflow actions.

**Validation**
- Verified working tree contains only Kanbus artifact updates.
- No source/runtime code changes in this PR.

**Expected Outcome**
- `develop` includes the missing Kanbus closure artifacts from the previous session.

**Kanbus / Task Tracking**
- `tcts-ec92c3`
