### PR TITLE
fix: preload persisted runtime state for continuation detection

### DIFF
--- a/project/issues/tcts-50df0579-70ce-4421-9eaf-0933f3b1fcaa.json
+++ b/project/issues/tcts-50df0579-70ce-4421-9eaf-0933f3b1fcaa.json
@@ -1,0 +1,25 @@
+{
+  "id": "tcts-50df0579-70ce-4421-9eaf-0933f3b1fcaa",
+  "title": "Preload persisted state into runtime State primitive for continuation detection",
+  "description": "",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "tcts-9916e7f0-28e6-4046-a3b2-a16c20b1897f",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "ee0fa859-0785-4408-81d8-b9f567512376",
+      "author": "ryan",
+      "text": "Landing runtime state-preload change from local workspace: preload persisted procedure state into State primitive during runtime setup to support continuation detection and State.get-based branching in Lua procedures. Will validate with focused runtime tests and full CI via PR.",
+      "created_at": "2026-04-20T17:11:20.616538Z"
+    }
+  ],
+  "created_at": "2026-04-20T17:11:15.714659Z",
+  "updated_at": "2026-04-20T17:11:20.616538Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/tcts-9916e7f0-28e6-4046-a3b2-a16c20b1897f.json
+++ b/project/issues/tcts-9916e7f0-28e6-4046-a3b2-a16c20b1897f.json
@@ -1,0 +1,18 @@
+{
+  "id": "tcts-9916e7f0-28e6-4046-a3b2-a16c20b1897f",
+  "title": "State preload for continuation detection",
+  "description": "",
+  "type": "epic",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-20T17:11:10.779476Z",
+  "updated_at": "2026-04-20T17:11:15.727777Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/tactus/core/runtime.py
+++ b/tactus/core/runtime.py
@@ -861,10 +861,9 @@ class TactusRuntime:
         # returns "table" and length operator # works correctly.
         if self.storage_backend and self.procedure_id:
             try:
-                existing_metadata = self.storage_backend.load_procedure_metadata(
-                    self.procedure_id
-                )
+                existing_metadata = self.storage_backend.load_procedure_metadata(self.procedure_id)
                 if existing_metadata and existing_metadata.state:
+
                     def _to_lua_value(value: Any) -> Any:
                         """Recursively convert Python list/dict to Lua table."""
                         if isinstance(value, list):
@@ -880,18 +879,14 @@ class TactusRuntime:
                         return value
 
                     for _state_key, _state_value in existing_metadata.state.items():
-                        self.state_primitive._state_values[_state_key] = (
-                            _to_lua_value(_state_value)
-                        )
+                        self.state_primitive._state_values[_state_key] = _to_lua_value(_state_value)
                     logger.info(
                         "Preloaded %d state keys from storage backend for procedure %s",
                         len(existing_metadata.state),
                         self.procedure_id,
                     )
             except Exception as _preload_err:
-                logger.warning(
-                    "Could not preload state from storage backend: %s", _preload_err
-                )
+                logger.warning("Could not preload state from storage backend: %s", _preload_err)
 
         self.iterations_primitive = IterationsPrimitive()
         self.stop_primitive = StopPrimitive()

--- a/tactus/core/runtime.py
+++ b/tactus/core/runtime.py
@@ -852,6 +852,47 @@ class TactusRuntime:
                 _storage.state_set(_proc_id, key, value)
 
         self.state_primitive = StatePrimitive(state_schema=state_schema, on_set=_on_set)
+
+        # Pre-populate state from storage backend if available.
+        # This allows continuation detection: Lua code can call State.get("iterations")
+        # and find the prior accumulated state from a previous run.
+        # We bypass on_set here (direct dict access) to avoid re-persisting unchanged values.
+        # Python lists/dicts must be converted to Lua tables so that Lua's type() check
+        # returns "table" and length operator # works correctly.
+        if self.storage_backend and self.procedure_id:
+            try:
+                existing_metadata = self.storage_backend.load_procedure_metadata(
+                    self.procedure_id
+                )
+                if existing_metadata and existing_metadata.state:
+                    def _to_lua_value(value: Any) -> Any:
+                        """Recursively convert Python list/dict to Lua table."""
+                        if isinstance(value, list):
+                            lua_table = self.lua_sandbox.lua.table()
+                            for _i, _item in enumerate(value, 1):
+                                lua_table[_i] = _to_lua_value(_item)
+                            return lua_table
+                        elif isinstance(value, dict):
+                            lua_table = self.lua_sandbox.lua.table()
+                            for _k, _v in value.items():
+                                lua_table[_k] = _to_lua_value(_v)
+                            return lua_table
+                        return value
+
+                    for _state_key, _state_value in existing_metadata.state.items():
+                        self.state_primitive._state_values[_state_key] = (
+                            _to_lua_value(_state_value)
+                        )
+                    logger.info(
+                        "Preloaded %d state keys from storage backend for procedure %s",
+                        len(existing_metadata.state),
+                        self.procedure_id,
+                    )
+            except Exception as _preload_err:
+                logger.warning(
+                    "Could not preload state from storage backend: %s", _preload_err
+                )
+
         self.iterations_primitive = IterationsPrimitive()
         self.stop_primitive = StopPrimitive()
 


### PR DESCRIPTION
## Summary
- preload persisted procedure state into `StatePrimitive` at runtime setup when storage backend metadata exists
- recursively convert Python lists/dicts from storage into Lua tables so Lua `type(...) == "table"` and `#` length semantics work
- keep preload best-effort with warning log on failure

## Why
Continuation logic in Lua procedures needs prior state (for example `State.get("iterations")`) immediately at startup before new writes occur.

## Validation
- `python3 -m pytest -q tests/core/test_runtime_execute_branches.py -k "storage or state or runtime"`
- `python3 -m pytest -q tests/adapters/test_memory_storage.py tests/adapters/test_file_storage.py`
