### PR TITLE
Add host-registered Python modules

### DIFF
--- a/docs/SANDBOXING.md
+++ b/docs/SANDBOXING.md
@@ -53,6 +53,7 @@ Each layer addresses a different security concern:
 - **Restricted VM:** Lua procedures run in a sandboxed virtual machine
 - **Limited stdlib:** Only safe standard library functions are exposed
 - **Tool-mediated access:** All I/O operations must go through registered tools
+- **Host-registered modules:** Embedding applications may explicitly register Python-backed modules for `require()`
 - **No eval:** Dynamic code execution is disabled
 
 ## Example: Embeddable Safety
@@ -80,6 +81,49 @@ Lua sandboxing **cannot** protect against:
 - Agents consuming excessive memory or CPU
 
 For these threats, you need **OS-level sandboxing** (Docker or cloud).
+
+## Host-Registered Python Modules
+
+Embedding applications can expose application-specific capabilities to Lua
+without adding those capabilities to the Tactus standard library. Register the
+module on a runtime before execution:
+
+```python
+from tactus import TactusRuntime
+
+runtime = TactusRuntime(procedure_id="example")
+runtime.register_python_module("plexus", plexus_module)
+
+result = await runtime.execute(
+    """
+    local plexus = require("plexus")
+    local score = plexus.score.info({ id = "score_123" })
+    return { name = score.name }
+    """,
+    format="lua",
+)
+```
+
+Host modules are explicit capabilities:
+
+- Names must be dotted identifiers such as `plexus` or `vendor.analytics`.
+- The `tactus.*` namespace is reserved for the Tactus standard library.
+- Host modules are per-runtime and are not arbitrary Python imports.
+- Host modules resolve before local `.tac` files, so a local file cannot shadow
+  an explicit capability such as `require("plexus")`.
+- Tactus stdlib Python modules remain fallback behavior after `.tac` searchers,
+  preserving the existing Tactus-first loading order for `tactus.*`.
+- Re-registering a host module clears Lua's `require` cache for that name.
+
+Security guidance:
+
+- Treat every host module as a capability grant. Do not register broad objects
+  that expose filesystem, network, secrets, or process control unless that is
+  the intended capability.
+- Prefer narrow facade objects with explicit public methods.
+- Private attributes and dangerous Python attributes remain blocked by the Lua
+  sandbox attribute filter, but capability design is still the host
+  application's responsibility.
 
 ---
 

--- a/tactus/core/lua_sandbox.py
+++ b/tactus/core/lua_sandbox.py
@@ -235,49 +235,67 @@ class LuaSandbox:
         self._stdlib_loader = StdlibModuleLoader(
             self,
             self.base_path,
-            host_modules=self.python_modules,
+            host_modules=getattr(self, "python_modules", {}),
         )
-        host_loader_func = self._stdlib_loader.create_host_loader_function()
         stdlib_loader_func = self._stdlib_loader.create_loader_function()
 
         # Inject loader function into Lua
-        self.lua.globals()["_tactus_host_python_loader"] = host_loader_func
         self.lua.globals()["_tactus_python_loader"] = stdlib_loader_func
 
         # Add to package.loaders (Lua 5.1) or package.searchers (Lua 5.2+)
         # Lupa uses LuaJIT which follows Lua 5.1 conventions
-        self.lua.execute("""
-            -- Add host and Python stdlib loaders to package.loaders.
-            local loaders = package.loaders or package.searchers
-            if loaders then
-                -- Host modules are explicit capabilities provided by the
-                -- embedding application. They run before .tac searchers so a
-                -- local file cannot shadow require("plexus").
-                local function host_python_searcher(modname)
-                    local result = _tactus_host_python_loader(modname)
-                    if result then
-                        return function() return result end
+        create_host_loader = getattr(self._stdlib_loader, "create_host_loader_function", None)
+        if callable(create_host_loader):
+            host_loader_func = create_host_loader()
+            self.lua.globals()["_tactus_host_python_loader"] = host_loader_func
+            self.lua.execute("""
+                -- Add host and Python stdlib loaders to package.loaders.
+                local loaders = package.loaders or package.searchers
+                if loaders then
+                    -- Host modules are explicit capabilities provided by the
+                    -- embedding application. They run before .tac searchers so a
+                    -- local file cannot shadow require("plexus").
+                    local function host_python_searcher(modname)
+                        local result = _tactus_host_python_loader(modname)
+                        if result then
+                            return function() return result end
+                        end
+                        return nil
                     end
-                    return nil
-                end
 
-                -- Stdlib Python modules are fallback after .tac path loaders.
-                local function stdlib_python_searcher(modname)
-                    local result = _tactus_python_loader(modname)
-                    if result then
-                        return function() return result end
+                    -- Stdlib Python modules are fallback after .tac path loaders.
+                    local function stdlib_python_searcher(modname)
+                        local result = _tactus_python_loader(modname)
+                        if result then
+                            return function() return result end
+                        end
+                        return nil
                     end
-                    return nil
+
+                    -- Insert host modules before filesystem searchers. Lua's first
+                    -- searcher handles package.preload, so index 2 preserves that.
+                    table.insert(loaders, 2, host_python_searcher)
+
+                    -- Append stdlib at end so .tac files are checked first.
+                    table.insert(loaders, stdlib_python_searcher)
                 end
+                """)
+        else:
+            self.lua.execute("""
+                -- Add Python stdlib loader to package.loaders.
+                local loaders = package.loaders or package.searchers
+                if loaders then
+                    local function stdlib_python_searcher(modname)
+                        local result = _tactus_python_loader(modname)
+                        if result then
+                            return function() return result end
+                        end
+                        return nil
+                    end
 
-                -- Insert host modules before filesystem searchers. Lua's first
-                -- searcher handles package.preload, so index 2 preserves that.
-                table.insert(loaders, 2, host_python_searcher)
-
-                -- Append stdlib at end so .tac files are checked first.
-                table.insert(loaders, stdlib_python_searcher)
-            end
-            """)
+                    table.insert(loaders, stdlib_python_searcher)
+                end
+                """)
 
         logger.debug("Python host/stdlib loaders installed")
 

--- a/tactus/core/lua_sandbox.py
+++ b/tactus/core/lua_sandbox.py
@@ -38,8 +38,7 @@ def validate_python_module_name(name: str) -> None:
         raise ValueError("Host modules cannot use the reserved 'tactus.' namespace")
     if not HOST_MODULE_NAME_PATTERN.match(name):
         raise ValueError(
-            "Host module names must be dotted identifiers, e.g. 'plexus' or "
-            "'vendor.module'"
+            "Host module names must be dotted identifiers, e.g. 'plexus' or " "'vendor.module'"
         )
 
 

--- a/tactus/core/lua_sandbox.py
+++ b/tactus/core/lua_sandbox.py
@@ -4,7 +4,8 @@ Lua Sandbox - Safe, restricted Lua execution environment.
 Provides a sandboxed Lua runtime with:
 - Data format libraries restricted to working directory (Csv, Tsv, Parquet, Hdf5, Excel)
 - File and Json primitives injected separately by runtime
-- require() available but restricted to loading .tac files from working directory only
+- require() available but restricted to host-registered modules, .tac files from
+  working directory, and Tactus stdlib modules
 - No dangerous operations (debug, io, loadfile, dofile removed)
 - Only whitelisted primitives available
 - Resource limits on CPU time and memory
@@ -12,6 +13,7 @@ Provides a sandboxed Lua runtime with:
 
 import logging
 import os
+import re
 from typing import Any, Optional
 
 try:
@@ -24,6 +26,21 @@ except ImportError:
     LuaRuntime = None
 
 logger = logging.getLogger(__name__)
+HOST_MODULE_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$")
+
+
+def validate_python_module_name(name: str) -> None:
+    """Validate a host-provided Lua require() module name."""
+
+    if not name or not isinstance(name, str):
+        raise ValueError("Module name must be a non-empty string")
+    if name.startswith("tactus."):
+        raise ValueError("Host modules cannot use the reserved 'tactus.' namespace")
+    if not HOST_MODULE_NAME_PATTERN.match(name):
+        raise ValueError(
+            "Host module names must be dotted identifiers, e.g. 'plexus' or "
+            "'vendor.module'"
+        )
 
 
 class LuaSandboxError(Exception):
@@ -40,6 +57,7 @@ class LuaSandbox:
         execution_context: Optional[Any] = None,
         strict_determinism: bool = False,
         base_path: Optional[str] = None,
+        python_modules: Optional[dict[str, Any]] = None,
     ):
         """
         Initialize the Lua sandbox.
@@ -48,6 +66,7 @@ class LuaSandbox:
             execution_context: Optional ExecutionContext for checkpoint scope tracking
             strict_determinism: If True, raise errors instead of warnings for non-deterministic ops
             base_path: Optional base path for file operations and require(). Defaults to cwd.
+            python_modules: Optional host-provided Python modules available via require().
         """
         if not LUPA_AVAILABLE:
             raise LuaSandboxError("lupa library not available. Install with: pip install lupa")
@@ -60,6 +79,13 @@ class LuaSandbox:
         # This ensures file I/O libraries and require() always use the same base path,
         # even if the working directory changes later
         self.base_path = base_path or os.getcwd()
+        self.python_modules = {}
+        for name, module in (python_modules or {}).items():
+            try:
+                validate_python_module_name(name)
+            except ValueError as exc:
+                raise LuaSandboxError(str(exc)) from exc
+            self.python_modules[name] = module
 
         # Create Lua runtime with safety restrictions
         self.lua = LuaRuntime(
@@ -207,35 +233,74 @@ class LuaSandbox:
         from tactus.stdlib.loader import StdlibModuleLoader
 
         # Create loader instance
-        self._stdlib_loader = StdlibModuleLoader(self, self.base_path)
-        loader_func = self._stdlib_loader.create_loader_function()
+        self._stdlib_loader = StdlibModuleLoader(
+            self,
+            self.base_path,
+            host_modules=self.python_modules,
+        )
+        host_loader_func = self._stdlib_loader.create_host_loader_function()
+        stdlib_loader_func = self._stdlib_loader.create_loader_function()
 
         # Inject loader function into Lua
-        self.lua.globals()["_tactus_python_loader"] = loader_func
+        self.lua.globals()["_tactus_host_python_loader"] = host_loader_func
+        self.lua.globals()["_tactus_python_loader"] = stdlib_loader_func
 
         # Add to package.loaders (Lua 5.1) or package.searchers (Lua 5.2+)
         # Lupa uses LuaJIT which follows Lua 5.1 conventions
         self.lua.execute("""
-            -- Add Python stdlib loader to package.loaders
-            -- Append at end so .tac files are checked first (Tactus-first architecture)
+            -- Add host and Python stdlib loaders to package.loaders.
             local loaders = package.loaders or package.searchers
             if loaders then
-                -- Create wrapper that returns a loader function (Lua convention)
-                local function python_searcher(modname)
-                    local result = _tactus_python_loader(modname)
+                -- Host modules are explicit capabilities provided by the
+                -- embedding application. They run before .tac searchers so a
+                -- local file cannot shadow require("plexus").
+                local function host_python_searcher(modname)
+                    local result = _tactus_host_python_loader(modname)
                     if result then
-                        -- Return a loader function that returns the module
                         return function() return result end
                     end
                     return nil
                 end
 
-                -- Append at end (.tac path loader runs first, Python is fallback)
-                table.insert(loaders, python_searcher)
+                -- Stdlib Python modules are fallback after .tac path loaders.
+                local function stdlib_python_searcher(modname)
+                    local result = _tactus_python_loader(modname)
+                    if result then
+                        return function() return result end
+                    end
+                    return nil
+                end
+
+                -- Insert host modules before filesystem searchers. Lua's first
+                -- searcher handles package.preload, so index 2 preserves that.
+                table.insert(loaders, 2, host_python_searcher)
+
+                -- Append stdlib at end so .tac files are checked first.
+                table.insert(loaders, stdlib_python_searcher)
             end
             """)
 
-        logger.debug("Python stdlib loader installed")
+        logger.debug("Python host/stdlib loaders installed")
+
+    def register_python_module(self, name: str, module: Any) -> None:
+        """Register a host-provided Python module for Lua require().
+
+        Registered modules are resolved by the same safe Python loader used for
+        the Tactus stdlib. They are per-sandbox and do not expand filesystem
+        search paths or enable arbitrary Python imports.
+        """
+
+        try:
+            validate_python_module_name(name)
+        except ValueError as exc:
+            raise LuaSandboxError(str(exc)) from exc
+
+        self.python_modules[name] = module
+        if hasattr(self, "_stdlib_loader"):
+            self._stdlib_loader.register_host_module(name, module)
+        package = self.lua.globals()["package"]
+        if package and package["loaded"]:
+            package["loaded"][name] = None
 
     def _setup_safe_globals(self) -> None:
         """Setup safe global functions and utilities."""

--- a/tactus/core/runtime.py
+++ b/tactus/core/runtime.py
@@ -254,12 +254,25 @@ class TactusRuntime:
 
             sandbox_base_path = self._resolve_sandbox_base_path()
 
-            self.lua_sandbox = LuaSandbox(
-                execution_context=None,
-                strict_determinism=strict_determinism,
-                base_path=sandbox_base_path,
-                python_modules=self.python_modules,
-            )
+            try:
+                self.lua_sandbox = LuaSandbox(
+                    execution_context=None,
+                    strict_determinism=strict_determinism,
+                    base_path=sandbox_base_path,
+                    python_modules=self.python_modules,
+                )
+            except TypeError as exc:
+                if "python_modules" not in str(exc):
+                    raise
+                self.lua_sandbox = LuaSandbox(
+                    execution_context=None,
+                    strict_determinism=strict_determinism,
+                    base_path=sandbox_base_path,
+                )
+                register_module = getattr(self.lua_sandbox, "register_python_module", None)
+                if callable(register_module):
+                    for name, module in self.python_modules.items():
+                        register_module(name, module)
 
             # 0.5. Create execution context EARLY so it's available during DSL parsing
             # This is critical for immediate agent creation during parsing

--- a/tactus/core/runtime.py
+++ b/tactus/core/runtime.py
@@ -21,7 +21,7 @@ from tactus.core.dsl_stubs import create_dsl_stubs, lua_table_to_dict
 from tactus.core.template_resolver import TemplateResolver
 from tactus.dspy.model_params import default_temperature_for_model
 from tactus.core.message_history_manager import MessageHistoryManager
-from tactus.core.lua_sandbox import LuaSandbox, LuaSandboxError
+from tactus.core.lua_sandbox import LuaSandbox, LuaSandboxError, validate_python_module_name
 from tactus.core.output_validator import OutputValidator, OutputValidationError
 from tactus.core.execution_context import BaseExecutionContext
 from tactus.core.exceptions import ProcedureWaitingForHuman, TactusRuntimeError
@@ -150,6 +150,7 @@ class TactusRuntime:
         self.dependency_prompt_handler = None
         self.run_id = run_id
         self.source_file_path = source_file_path
+        self.python_modules: Dict[str, Any] = {}
 
         # Will be initialized during setup
         self.config: Optional[Dict[str, Any]] = None  # Legacy YAML support
@@ -198,6 +199,23 @@ class TactusRuntime:
 
         logger.info("TactusRuntime initialized for procedure %s", procedure_id)
 
+    def register_python_module(self, name: str, module: Any) -> None:
+        """Register a host-provided Python module for Lua require().
+
+        This is intentionally a host-extension hook, not a stdlib import path.
+        The module is available only to this runtime instance and is resolved by
+        the sandbox's safe Python loader during `require(name)`.
+        """
+
+        try:
+            validate_python_module_name(name)
+        except ValueError as exc:
+            raise TactusRuntimeError(str(exc)) from exc
+
+        self.python_modules[name] = module
+        if self.lua_sandbox is not None:
+            self.lua_sandbox.register_python_module(name, module)
+
     async def execute(
         self,
         source: str,
@@ -240,6 +258,7 @@ class TactusRuntime:
                 execution_context=None,
                 strict_determinism=strict_determinism,
                 base_path=sandbox_base_path,
+                python_modules=self.python_modules,
             )
 
             # 0.5. Create execution context EARLY so it's available during DSL parsing

--- a/tactus/stdlib/loader.py
+++ b/tactus/stdlib/loader.py
@@ -1,9 +1,10 @@
 """
 Python stdlib module loader for Tactus.
 
-Provides a mechanism to load Python modules from tactus/stdlib/
-via Lua's require() function. Only modules with the "tactus." prefix
-can be loaded, ensuring user code cannot import arbitrary Python modules.
+Provides a mechanism to load Python modules from tactus/stdlib/ and
+host-registered Python modules via Lua's require() function. Only modules with
+the "tactus." prefix or explicit host registrations can be loaded, ensuring user
+code cannot import arbitrary Python modules.
 """
 
 import importlib.util
@@ -11,6 +12,7 @@ import inspect
 import logging
 import sys
 from pathlib import Path
+from types import ModuleType
 from typing import Any, Callable, Dict
 
 logger = logging.getLogger(__name__)
@@ -23,18 +25,30 @@ class StdlibModuleLoader:
     Security: Only loads from the stdlib path, never user directories.
     """
 
-    def __init__(self, lua_sandbox, base_path: str):
+    def __init__(
+        self,
+        lua_sandbox,
+        base_path: str,
+        host_modules: Dict[str, Any] | None = None,
+    ):
         """
         Initialize the stdlib loader.
 
         Args:
             lua_sandbox: LuaSandbox instance for table creation
             base_path: Base path for file operations (passed to modules)
+            host_modules: Explicit host-provided modules keyed by require() name.
         """
         self.lua_sandbox = lua_sandbox
         self.base_path = base_path
         self.stdlib_path = self._get_stdlib_path()
         self.loaded_modules: Dict[str, Any] = {}
+        self.host_modules: Dict[str, Any] = dict(host_modules or {})
+
+    def register_host_module(self, name: str, module: Any) -> None:
+        """Register a host-provided module object for Lua require()."""
+        self.host_modules[name] = module
+        self.loaded_modules.pop(name, None)
 
     def _get_stdlib_path(self) -> Path:
         """Get the stdlib directory path."""
@@ -45,7 +59,7 @@ class StdlibModuleLoader:
 
     def create_loader_function(self) -> Callable:
         """
-        Create the loader function to inject into Lua's package.loaders.
+        Create the stdlib loader function to inject into Lua's package.loaders.
 
         Returns:
             Python function that Lua can call as a module loader
@@ -61,7 +75,7 @@ class StdlibModuleLoader:
             Returns:
                 Lua table with module functions, or None if not found
             """
-            # Only handle tactus.* modules (stdlib)
+            # Only handle tactus.* modules from stdlib after host lookup.
             if not module_name.startswith("tactus."):
                 return None
 
@@ -91,6 +105,31 @@ class StdlibModuleLoader:
                 raise RuntimeError(f"Failed to load module '{module_name}': {e}")
 
         return python_stdlib_loader
+
+    def create_host_loader_function(self) -> Callable:
+        """Create a loader for explicit host modules.
+
+        This loader is intended to run before filesystem `.tac` searchers so a
+        host capability such as `require("plexus")` cannot be shadowed by a
+        local `plexus.tac` file.
+        """
+
+        def host_module_loader(module_name: str):
+            if module_name not in self.host_modules:
+                return None
+            return self._load_host_module(module_name, self.host_modules[module_name])
+
+        return host_module_loader
+
+    def _load_host_module(self, module_name: str, module: Any) -> Any:
+        """Convert an explicit host module object into a Lua module table."""
+        if module_name in self.loaded_modules:
+            return self.loaded_modules[module_name]
+
+        lua_table = self._create_lua_module_from_object(module)
+        self.loaded_modules[module_name] = lua_table
+        logger.debug(f"Loaded host Python module: {module_name}")
+        return lua_table
 
     def _load_python_module(self, module_name: str, path: Path) -> Any:
         """
@@ -191,6 +230,53 @@ class StdlibModuleLoader:
             lua_table[name] = wrapped
 
         return lua_table
+
+    def _create_lua_module_from_object(self, module: Any, *, _depth: int = 0) -> Any:
+        """Create a Lua module table from a host-provided Python object.
+
+        Host modules may be Python modules, dicts, or ordinary objects with
+        public callables / namespace attributes. Private attributes are skipped.
+        """
+        if _depth > 8:
+            raise RuntimeError("Host module nesting is too deep")
+
+        lua_table = self.lua_sandbox.lua.table()
+        for name, obj in self._host_module_items(module):
+            if not isinstance(name, str) or name.startswith("_"):
+                continue
+            if inspect.ismodule(obj) or inspect.isclass(obj):
+                continue
+            if callable(obj):
+                lua_table[name] = self._wrap_function(obj, name)
+            elif isinstance(obj, (str, int, float, bool, dict, list, tuple)) or obj is None:
+                lua_table[name] = self._python_to_lua(obj)
+            elif hasattr(obj, "__dict__"):
+                lua_table[name] = self._create_lua_module_from_object(obj, _depth=_depth + 1)
+
+        return lua_table
+
+    def _host_module_items(self, module: Any) -> list[tuple[str, Any]]:
+        """Return public host module members without evaluating object properties."""
+        if isinstance(module, dict):
+            return list(module.items())
+
+        if isinstance(module, ModuleType):
+            return [(name, getattr(module, name)) for name in dir(module)]
+
+        items: dict[str, Any] = {}
+        for name, obj in getattr(module, "__dict__", {}).items():
+            if not name.startswith("_"):
+                items[name] = obj
+
+        for name, raw_obj in inspect.getmembers_static(type(module)):
+            if name.startswith("_") or name in items:
+                continue
+            if isinstance(raw_obj, property):
+                continue
+            if callable(raw_obj):
+                items[name] = getattr(module, name)
+
+        return list(items.items())
 
     def _wrap_function(self, func: Callable, name: str) -> Callable:
         """

--- a/tactus/stdlib/loader.py
+++ b/tactus/stdlib/loader.py
@@ -268,13 +268,14 @@ class StdlibModuleLoader:
             if not name.startswith("_"):
                 items[name] = obj
 
-        for name, raw_obj in inspect.getmembers_static(type(module)):
-            if name.startswith("_") or name in items:
-                continue
-            if isinstance(raw_obj, property):
-                continue
-            if callable(raw_obj):
-                items[name] = getattr(module, name)
+        for cls in reversed(type(module).__mro__):
+            for name, raw_obj in getattr(cls, "__dict__", {}).items():
+                if name.startswith("_") or name in items:
+                    continue
+                if isinstance(raw_obj, property):
+                    continue
+                if callable(raw_obj) or isinstance(raw_obj, (staticmethod, classmethod)):
+                    items[name] = getattr(module, name)
 
         return list(items.items())
 

--- a/tests/stdlib/test_require_python.py
+++ b/tests/stdlib/test_require_python.py
@@ -2,7 +2,9 @@
 
 import json
 import pytest
+from tactus.adapters.memory import MemoryStorage
 from tactus.core.lua_sandbox import LuaSandbox
+from tactus.core.runtime import TactusRuntime
 
 
 class TestRequirePythonModule:
@@ -88,6 +90,27 @@ class TestRequirePythonModule:
         # Should load the .tac version
         result = sandbox.execute('local m = require("mymodule"); return m')
         assert result["type"] == "tac_module"
+
+    def test_host_module_preferred_over_local_tac_file(self, tmp_path):
+        """Test explicit host capabilities cannot be shadowed by local .tac files."""
+
+        (tmp_path / "plexus.tac").write_text("""
+            return {
+                source = "local_tac"
+            }
+        """)
+
+        sandbox = LuaSandbox(
+            base_path=str(tmp_path),
+            python_modules={"plexus": {"source": lambda: "host_module"}},
+        )
+
+        result = sandbox.execute("""
+            local plexus = require("plexus")
+            return plexus.source()
+        """)
+
+        assert result == "host_module"
 
     def test_exception_propagation(self, tmp_path):
         """Test that Python exceptions become Lua errors."""
@@ -200,3 +223,171 @@ class TestRequirePythonModule:
 
         assert data["message"] == "Hello"
         assert data["items"] == ["apple", "banana", "cherry"]
+
+    def test_require_host_registered_python_module(self, tmp_path):
+        """Test require('plexus') can resolve an explicit host module."""
+
+        class Scores:
+            def info(self, args):
+                return {
+                    "id": args["id"],
+                    "name": "Compliance Tone",
+                    "versions": ["v1", "v2"],
+                }
+
+        class Plexus:
+            def __init__(self):
+                self.score = Scores()
+
+            def ping(self):
+                return "pong"
+
+        sandbox = LuaSandbox(base_path=str(tmp_path), python_modules={"plexus": Plexus()})
+
+        result = sandbox.execute("""
+            local plexus = require("plexus")
+            local score = plexus.score.info({id = "score_1"})
+            return {
+                ping = plexus.ping(),
+                score_id = score.id,
+                score_name = score.name,
+                first_version = score.versions[1],
+                version_count = #score.versions
+            }
+        """)
+
+        assert result["ping"] == "pong"
+        assert result["score_id"] == "score_1"
+        assert result["score_name"] == "Compliance Tone"
+        assert result["first_version"] == "v1"
+        assert result["version_count"] == 2
+
+    def test_host_module_registration_does_not_evaluate_properties(self, tmp_path):
+        """Test host object properties are not evaluated while building the Lua module."""
+
+        class HostModule:
+            @property
+            def dangerous(self):
+                raise AssertionError("property should not be evaluated")
+
+            def safe(self):
+                return "ok"
+
+        sandbox = LuaSandbox(base_path=str(tmp_path), python_modules={"host": HostModule()})
+
+        result = sandbox.execute("""
+            local host = require("host")
+            return {
+                safe = host.safe(),
+                dangerous_is_nil = host.dangerous == nil
+            }
+        """)
+
+        assert result["safe"] == "ok"
+        assert result["dangerous_is_nil"] == True  # noqa: E712
+
+    def test_register_host_module_after_sandbox_creation(self, tmp_path):
+        """Test a host module can be registered after sandbox initialization."""
+
+        sandbox = LuaSandbox(base_path=str(tmp_path))
+        sandbox.register_python_module("host", {"answer": lambda: 42})
+
+        result = sandbox.execute("""
+            local host = require("host")
+            return host.answer()
+        """)
+
+        assert result == 42
+
+    def test_reregister_host_module_clears_lua_require_cache(self, tmp_path):
+        """Test re-registering a host module updates subsequent require() calls."""
+
+        sandbox = LuaSandbox(base_path=str(tmp_path))
+        sandbox.register_python_module("host", {"value": lambda: "first"})
+
+        first = sandbox.execute("""
+            local host = require("host")
+            return host.value()
+        """)
+
+        sandbox.register_python_module("host", {"value": lambda: "second"})
+
+        second = sandbox.execute("""
+            local host = require("host")
+            return host.value()
+        """)
+
+        assert first == "first"
+        assert second == "second"
+
+    def test_initial_host_modules_validate_reserved_namespace(self, tmp_path):
+        """Test constructor-supplied modules cannot use tactus.*."""
+
+        with pytest.raises(Exception) as exc_info:
+            LuaSandbox(
+                base_path=str(tmp_path),
+                python_modules={"tactus.fake": {"value": lambda: 1}},
+            )
+
+        assert "reserved" in str(exc_info.value).lower()
+
+    def test_host_module_name_must_be_dotted_identifier(self, tmp_path):
+        """Test host module names cannot be path-like or empty."""
+
+        sandbox = LuaSandbox(base_path=str(tmp_path))
+
+        for name in ["", "plexus/tools", "plexus-tools", "1plexus"]:
+            with pytest.raises(Exception) as exc_info:
+                sandbox.register_python_module(name, {"value": lambda: 1})
+            assert "module name" in str(exc_info.value).lower()
+
+    def test_unregistered_host_module_is_not_available(self, tmp_path):
+        """Test unknown non-stdlib modules remain unavailable."""
+        sandbox = LuaSandbox(base_path=str(tmp_path))
+
+        result = sandbox.execute("""
+            local status, err = pcall(function()
+                return require("not_registered")
+            end)
+            return {status = status, has_error = err ~= nil}
+        """)
+
+        assert result["status"] == False  # noqa: E712
+        assert result["has_error"] == True  # noqa: E712
+
+    def test_host_module_cannot_use_reserved_tactus_namespace(self, tmp_path):
+        """Test hosts cannot override the reserved tactus.* namespace."""
+        sandbox = LuaSandbox(base_path=str(tmp_path))
+
+        with pytest.raises(Exception) as exc_info:
+            sandbox.register_python_module("tactus.fake", {"value": lambda: 1})
+
+        assert "reserved" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_runtime_register_python_module(self, tmp_path):
+        """Test TactusRuntime exposes host modules to Lua execution."""
+
+        class HostModule:
+            def ping(self):
+                return {"message": "pong"}
+
+        runtime = TactusRuntime(
+            procedure_id="host-module-test",
+            storage_backend=MemoryStorage(),
+            hitl_handler=object(),
+            source_file_path=str(tmp_path / "procedure.tac"),
+        )
+        runtime.register_python_module("host", HostModule())
+
+        result = await runtime.execute(
+            """
+            local host = require("host")
+            local response = host.ping()
+            return response.message
+            """,
+            format="lua",
+        )
+
+        assert result["success"] == True  # noqa: E712
+        assert result["result"] == "pong"


### PR DESCRIPTION
## Summary
- Add per-runtime host Python module registration so embedding apps can expose explicit capabilities via `require("...")` without adding them to the Tactus stdlib.
- Teach the Lua sandbox/stdlib loader to resolve host modules before local `.tac` files while preserving Tactus stdlib fallback behavior.
- Document the host-module security model and add coverage for registration, shadowing, cache refresh, namespace validation, and runtime integration.

## Test plan
- `python -m pytest tests/stdlib/test_require_python.py -q`


Made with [Cursor](https://cursor.com)