### PR TITLE
Fix DSPy agent tool-loop finalization

### DIFF
--- a/project/events/2026-04-20T17:11:10.780Z__cd7243eb-b5f6-4b42-9b55-e2e10f33d6ea.json
+++ b/project/events/2026-04-20T17:11:10.780Z__cd7243eb-b5f6-4b42-9b55-e2e10f33d6ea.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "cd7243eb-b5f6-4b42-9b55-e2e10f33d6ea",
+  "issue_id": "tcts-9916e7f0-28e6-4046-a3b2-a16c20b1897f",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-20T17:11:10.780Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "epic",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "State preload for continuation detection"
+  }
+}

--- a/project/events/2026-04-20T17:11:15.714Z__ce943fa0-d4a6-47bc-98fd-5a952da4a5e6.json
+++ b/project/events/2026-04-20T17:11:15.714Z__ce943fa0-d4a6-47bc-98fd-5a952da4a5e6.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "ce943fa0-d4a6-47bc-98fd-5a952da4a5e6",
+  "issue_id": "tcts-50df0579-70ce-4421-9eaf-0933f3b1fcaa",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-20T17:11:15.714Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "tcts-9916e7f0-28e6-4046-a3b2-a16c20b1897f",
+    "priority": 1,
+    "status": "open",
+    "title": "Preload persisted state into runtime State primitive for continuation detection"
+  }
+}

--- a/project/events/2026-04-20T17:11:15.727Z__ad028e4e-ce0c-45db-bbe8-8464872306cf.json
+++ b/project/events/2026-04-20T17:11:15.727Z__ad028e4e-ce0c-45db-bbe8-8464872306cf.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ad028e4e-ce0c-45db-bbe8-8464872306cf",
+  "issue_id": "tcts-9916e7f0-28e6-4046-a3b2-a16c20b1897f",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-20T17:11:15.727Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-20T17:11:20.606Z__c93b819b-8530-4837-9199-944026411fa3.json
+++ b/project/events/2026-04-20T17:11:20.606Z__c93b819b-8530-4837-9199-944026411fa3.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "c93b819b-8530-4837-9199-944026411fa3",
+  "issue_id": "tcts-50df0579-70ce-4421-9eaf-0933f3b1fcaa",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-20T17:11:20.606Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-20T17:11:20.616Z__cd081067-501d-4810-a9ec-92fbffce8268.json
+++ b/project/events/2026-04-20T17:11:20.616Z__cd081067-501d-4810-a9ec-92fbffce8268.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "cd081067-501d-4810-a9ec-92fbffce8268",
+  "issue_id": "tcts-50df0579-70ce-4421-9eaf-0933f3b1fcaa",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-20T17:11:20.616Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "ee0fa859-0785-4408-81d8-b9f567512376"
+  }
+}

--- a/project/events/2026-04-20T17:14:29.283Z__3daf1ef6-22cc-4d9f-bcea-0ff892046103.json
+++ b/project/events/2026-04-20T17:14:29.283Z__3daf1ef6-22cc-4d9f-bcea-0ff892046103.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "3daf1ef6-22cc-4d9f-bcea-0ff892046103",
+  "issue_id": "tcts-50df0579-70ce-4421-9eaf-0933f3b1fcaa",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-20T17:14:29.283Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "c61e7b95-d0b8-472a-ac91-97e471ae77e6"
+  }
+}

--- a/project/events/2026-04-29T03:01:44.188Z__99542bd7-2b4b-4a65-8433-322fafad207e.json
+++ b/project/events/2026-04-29T03:01:44.188Z__99542bd7-2b4b-4a65-8433-322fafad207e.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "99542bd7-2b4b-4a65-8433-322fafad207e",
+  "issue_id": "tcts-95c70987-7f96-4be2-86e7-d0ba514f0fba",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-29T03:01:44.188Z",
+  "actor_id": "ryan",
+  "payload": {
+    "title": "Fix DSPy agent multi-tool turn loop",
+    "description": "Feature: Agent tool loops finalize from tool results\n\nScenario: An agent calls a tool and then answers\nGiven a DSPy agent receives a user turn that requires a tool\nWhen the model returns a tool call and then receives the tool result\nThen Tactus calls the model again with updated history\nAnd the final assistant answer can use the tool result\n\nScenario: An agent chains tools before answering\nGiven a DSPy agent needs multiple tool calls in one user turn\nWhen the model returns more tool calls after a tool result\nThen Tactus continues the tool loop\nAnd stops only when the model returns a normal assistant answer\n\nScenario: A terminal turn has no text\nGiven the model returns no further tool calls and no usable assistant text\nWhen Tactus detects the missing final answer\nThen it performs one explicit final synthesis call from the current history.",
+    "issue_type": "bug",
+    "status": "open",
+    "priority": 1,
+    "assignee": null,
+    "parent": null,
+    "labels": []
+  }
+}

--- a/project/events/2026-04-29T03:01:48.287Z__25439219-7ca1-450f-a207-68238fa919ba.json
+++ b/project/events/2026-04-29T03:01:48.287Z__25439219-7ca1-450f-a207-68238fa919ba.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "25439219-7ca1-450f-a207-68238fa919ba",
+  "issue_id": "tcts-95c70987-7f96-4be2-86e7-d0ba514f0fba",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-29T03:01:48.287Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-29T03:01:48.855Z__6ad33d59-747e-429a-9a70-eb89961821ab.json
+++ b/project/events/2026-04-29T03:01:48.855Z__6ad33d59-747e-429a-9a70-eb89961821ab.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "6ad33d59-747e-429a-9a70-eb89961821ab",
+  "issue_id": "tcts-95c70987-7f96-4be2-86e7-d0ba514f0fba",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T03:01:48.855Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_id": "357fa1c6-7cbd-4746-a7f5-0aa840e9f37b",
+    "comment_author": "ryan"
+  }
+}

--- a/project/events/2026-04-29T03:03:16.490Z__067daa15-9e9f-42f5-91c7-c6575537f839.json
+++ b/project/events/2026-04-29T03:03:16.490Z__067daa15-9e9f-42f5-91c7-c6575537f839.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "067daa15-9e9f-42f5-91c7-c6575537f839",
+  "issue_id": "tcts-95c70987-7f96-4be2-86e7-d0ba514f0fba",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T03:03:16.490Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_id": "41959537-593d-4d58-9fcb-be87c9214246",
+    "comment_author": "ryan"
+  }
+}

--- a/project/events/2026-04-29T03:03:16.929Z__a82ba98a-68aa-49fc-8905-6169069f133d.json
+++ b/project/events/2026-04-29T03:03:16.929Z__a82ba98a-68aa-49fc-8905-6169069f133d.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a82ba98a-68aa-49fc-8905-6169069f133d",
+  "issue_id": "tcts-95c70987-7f96-4be2-86e7-d0ba514f0fba",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-29T03:03:16.929Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/tcts-95c70987-7f96-4be2-86e7-d0ba514f0fba.json
+++ b/project/issues/tcts-95c70987-7f96-4be2-86e7-d0ba514f0fba.json
@@ -1,0 +1,31 @@
+{
+  "id": "tcts-95c70987-7f96-4be2-86e7-d0ba514f0fba",
+  "title": "Fix DSPy agent multi-tool turn loop",
+  "description": "Feature: Agent tool loops finalize from tool results\n\nScenario: An agent calls a tool and then answers\nGiven a DSPy agent receives a user turn that requires a tool\nWhen the model returns a tool call and then receives the tool result\nThen Tactus calls the model again with updated history\nAnd the final assistant answer can use the tool result\n\nScenario: An agent chains tools before answering\nGiven a DSPy agent needs multiple tool calls in one user turn\nWhen the model returns more tool calls after a tool result\nThen Tactus continues the tool loop\nAnd stops only when the model returns a normal assistant answer\n\nScenario: A terminal turn has no text\nGiven the model returns no further tool calls and no usable assistant text\nWhen Tactus detects the missing final answer\nThen it performs one explicit final synthesis call from the current history.",
+  "type": "bug",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "357fa1c6-7cbd-4746-a7f5-0aa840e9f37b",
+      "author": "ryan",
+      "text": "Implemented DSPy agent tool-loop fix locally: streaming and non-streaming turns now repeat model calls after tool execution using updated history and blank follow-up user input; forced synthesis is only used when a terminal cycle has no usable text. Live Plexus console smoke verified tool call plus final answer.",
+      "created_at": "2026-04-29T03:01:48.855153Z"
+    },
+    {
+      "id": "41959537-593d-4d58-9fcb-be87c9214246",
+      "author": "ryan",
+      "text": "Verification before commit: pytest tests/dspy/test_agent_tool_loop.py passed (6 tests); ruff check passed for tactus/dspy/agent.py and tests/dspy/test_agent_tool_loop.py; black --check passed for both files.",
+      "created_at": "2026-04-29T03:03:16.489513Z"
+    }
+  ],
+  "created_at": "2026-04-29T03:01:44.188176Z",
+  "updated_at": "2026-04-29T03:03:16.929071Z",
+  "closed_at": "2026-04-29T03:03:16.929071Z",
+  "custom": {}
+}

--- a/tactus/dspy/agent.py
+++ b/tactus/dspy/agent.py
@@ -952,6 +952,110 @@ class DSPyAgentHandle:
             logger.info(f"[LLM_DEBUG] TOOL CALLS: {dspy_result.tool_calls}")
         logger.info("=" * 80)
 
+    @staticmethod
+    def _to_tool_calls_list(dspy_result: Any) -> List[Dict[str, Any]]:
+        """Convert DSPy tool_calls payload to history-compatible OpenAI tool call dicts."""
+        if not hasattr(dspy_result, "tool_calls") or not dspy_result.tool_calls:
+            return []
+
+        tool_calls_list: List[Dict[str, Any]] = []
+        raw_calls = (
+            dspy_result.tool_calls.tool_calls
+            if hasattr(dspy_result.tool_calls, "tool_calls")
+            else []
+        )
+        for tc in raw_calls:
+            tc_name, tc_args = _tool_call_name_and_args(tc)
+            tool_calls_list.append(
+                {
+                    "id": _tool_call_id_for_history(tc),
+                    "type": "function",
+                    "function": {
+                        "name": tc_name,
+                        "arguments": json.dumps(tc_args) if isinstance(tc_args, dict) else tc_args,
+                    },
+                }
+            )
+        return tool_calls_list
+
+    def _record_tool_execution(
+        self, tool_name: str, tool_args: Dict[str, Any], tool_result: Any
+    ) -> None:
+        """Record tool execution in ToolPrimitive when available."""
+        tool_primitive = getattr(self, "_tool_primitive", None)
+        if not tool_primitive:
+            return
+        clean_tool_name = tool_name.replace(f"{self.name}_", "")
+        try:
+            tool_primitive.record_call(
+                clean_tool_name,
+                tool_args,
+                tool_result,
+                agent_name=self.name,
+            )
+        except Exception:
+            logger.debug("Failed to record tool execution for '%s'", clean_tool_name, exc_info=True)
+
+    def _execute_assistant_tool_calls(
+        self,
+        assistant_msg: Dict[str, Any],
+        new_messages: List[Dict[str, Any]],
+    ) -> bool:
+        """Execute tool calls from an assistant message and append tool messages to history."""
+        tool_calls = assistant_msg.get("tool_calls") or []
+        if not tool_calls:
+            return False
+
+        for tc in tool_calls:
+            tool_name = tc["function"]["name"]
+            tool_args_str = tc["function"]["arguments"]
+            tool_args = (
+                json.loads(tool_args_str) if isinstance(tool_args_str, str) else tool_args_str
+            )
+            tool_id = tc["id"]
+
+            tool_result = self._execute_tool(tool_name, tool_args)
+            self._record_tool_execution(tool_name, tool_args, tool_result)
+
+            tool_result_str = (
+                json.dumps(tool_result) if isinstance(tool_result, dict) else str(tool_result)
+            )
+            tool_result_msg = {
+                "role": "tool",
+                "tool_call_id": tool_id,
+                "name": tool_name,
+                "content": tool_result_str,
+            }
+            new_messages.append(tool_result_msg)
+            self._history.add(tool_result_msg)
+
+        return True
+
+    @staticmethod
+    def _is_usable_assistant_text(text: Any) -> bool:
+        return isinstance(text, str) and text.strip() != ""
+
+    def _synthesis_prompt_context(self, prompt_context: Dict[str, Any]) -> Dict[str, Any]:
+        """Build a one-shot finalization prompt context for no-text terminal turns."""
+        synthesized = dict(prompt_context)
+        synthesized["user_message"] = (
+            "Provide the final user-facing answer now using prior tool results. "
+            "Do not call tools."
+        )
+        return synthesized
+
+    def _tool_followup_prompt_context(self, prompt_context: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Build prompt context for the next model call after tool execution.
+
+        Important: the original turn user_message must not be re-sent after tools run.
+        Follow-up calls should rely on accumulated history (assistant tool call + tool results).
+        """
+        followup = dict(prompt_context)
+        followup["history"] = self._history_from_messages(self._history.get())
+        followup["user_message"] = ""
+        return followup
+
     def _turn_with_streaming(
         self,
         opts: Dict[str, Any],
@@ -973,299 +1077,140 @@ class DSPyAgentHandle:
         """
         from tactus.protocols.models import AgentTurnEvent, AgentStreamChunkEvent
 
-        # logger.info(f"[STREAMING] Agent '{self.name}' starting streaming turn")
+        def _stream_once(current_prompt_context: Dict[str, Any]) -> Any:
+            # Queue for passing chunks from streaming thread to main thread
+            chunk_queue = queue.Queue()
+            result_holder = {"result": None, "error": None}
 
-        # Debug: log full LLM input
+            def run_streaming_in_thread():
+                dspy_thread = dspy
+
+                async def async_streaming():
+                    try:
+                        streaming_module = dspy_thread.streamify(self._module.module)
+                        stream = streaming_module(**current_prompt_context)
+                        async for value in stream:
+                            if isinstance(value, dspy_thread.Prediction):
+                                result_holder["result"] = value
+                            elif hasattr(value, "choices") and value.choices:
+                                delta = value.choices[0].delta
+                                if hasattr(delta, "content") and delta.content:
+                                    chunk_queue.put(("chunk", delta.content))
+                            elif isinstance(value, str) and value:
+                                chunk_queue.put(("chunk", value))
+                    except Exception as e:
+                        result_holder["error"] = e
+                    finally:
+                        chunk_queue.put(("done", None))
+
+                asyncio.run(async_streaming())
+
+            streaming_thread = threading.Thread(target=run_streaming_in_thread, daemon=True)
+            streaming_thread.start()
+            accumulated_text = ""
+            while True:
+                try:
+                    msg_type, msg_data = chunk_queue.get(timeout=120.0)
+                    if msg_type == "done":
+                        break
+                    if msg_type == "chunk" and msg_data:
+                        accumulated_text += msg_data
+                        self.log_handler.log(
+                            AgentStreamChunkEvent(
+                                agent_name=self.name,
+                                chunk_text=msg_data,
+                                accumulated_text=accumulated_text,
+                            )
+                        )
+                except queue.Empty:
+                    break
+            streaming_thread.join(timeout=5.0)
+
+            if result_holder["error"] is not None:
+                error = result_holder["error"]
+                original_error = error
+                if hasattr(error, "__class__") and error.__class__.__name__.endswith(
+                    "ExceptionGroup"
+                ):
+                    if hasattr(error, "exceptions") and error.exceptions:
+                        original_error = error.exceptions[0]
+                error_str = str(original_error).lower()
+                error_type = str(type(original_error).__name__)
+                if "authenticationerror" in error_type.lower() or "api_key" in error_str:
+                    from tactus.core.exceptions import TactusRuntimeError
+
+                    raise TactusRuntimeError(
+                        f"API authentication failed for agent '{self.name}': "
+                        f"Missing or invalid API key. Please configure your API key in Settings (Cmd+,)."
+                    ) from error
+                if original_error is not error:
+                    logger.error(
+                        f"Agent '{self.name}' ExceptionGroup sub-exception: "
+                        f"{type(original_error).__name__}: {original_error}"
+                    )
+                    raise RuntimeError(
+                        f"Agent '{self.name}' failed: {type(original_error).__name__}: {original_error}"
+                    ) from original_error
+                raise result_holder["error"]
+
+            if result_holder["result"] is None:
+                raise RuntimeError("Streaming produced no result")
+            return result_holder["result"]
+
         if os.environ.get("PLEXUS_DEBUG_LLM"):
             self._log_llm_debug_input(prompt_context)
 
-        # Emit turn started event so the UI shows a loading indicator
-        self.log_handler.log(
-            AgentTurnEvent(
-                agent_name=self.name,
-                stage="started",
-            )
-        )
-        # logger.info(f"[STREAMING] Agent '{self.name}' emitted AgentTurnEvent(started)")
+        self.log_handler.log(AgentTurnEvent(agent_name=self.name, stage="started"))
 
-        # Queue for passing chunks from streaming thread to main thread
-        chunk_queue = queue.Queue()
-        result_holder = {"result": None, "error": None}
-
-        def run_streaming_in_thread():
-            """Run DSPy streaming in a separate thread with its own event loop."""
-            dspy_thread = dspy
-
-            async def async_streaming():
-                """Async function that runs the streaming module."""
-                try:
-                    # Create a streaming version of the module using DSPy's streamify
-                    # NOTE: streamify() automatically enables streaming on the LM
-                    # We do NOT need to use settings.context(stream=True) - that actually breaks it!
-                    streaming_module = dspy_thread.streamify(self._module.module)
-                    # logger.info(
-                    #     f"[STREAMING] Agent '{self.name}' created streaming module"
-                    # )
-
-                    # Call the streaming module - it returns an async generator
-                    stream = streaming_module(**prompt_context)
-
-                    chunk_count = 0
-                    async for value in stream:
-                        chunk_count += 1
-                        # Check for final Prediction first
-                        if isinstance(value, dspy_thread.Prediction):
-                            # Final prediction - this is the result
-                            # logger.info(
-                            #     f"[STREAMING] Agent '{self.name}' received final Prediction"
-                            # )
-                            result_holder["result"] = value
-                        # Check for ModelResponseStream (the actual streaming chunks!)
-                        elif hasattr(value, "choices") and value.choices:
-                            delta = value.choices[0].delta
-                            if hasattr(delta, "content") and delta.content:
-                                # logger.info(
-                                #     f"[STREAMING] Agent '{self.name}' "
-                                #     f"chunk #{chunk_count}: '{delta.content}'"
-                                # )
-                                chunk_queue.put(("chunk", delta.content))
-                        # String chunks (shouldn't happen with DSPy but handle it anyway)
-                        elif isinstance(value, str):
-                            # logger.info(
-                            #     f"[STREAMING] Agent '{self.name}' "
-                            #     f"got STRING chunk, len={len(value)}"
-                            # )
-                            if value:
-                                chunk_queue.put(("chunk", value))
-                        else:
-                            pass
-
-                    # logger.info(
-                    #     f"[STREAMING] Agent '{self.name}' "
-                    #     f"stream finished, processed {chunk_count} values"
-                    # )
-
-                except Exception as e:
-                    # logger.error(
-                    #     f"[STREAMING] Agent '{self.name}' error: {e}",
-                    #     exc_info=True,
-                    # )
-                    result_holder["error"] = e
-                finally:
-                    # Signal end of stream
-                    chunk_queue.put(("done", None))
-
-            # Run the async function in this thread's new event loop
-            asyncio.run(async_streaming())
-
-        # Start streaming in a separate thread
-        streaming_thread = threading.Thread(target=run_streaming_in_thread, daemon=True)
-        streaming_thread.start()
-
-        # Consume chunks from the queue and emit events in the main thread
-        accumulated_text = ""
-        emitted_count = 0
-        # logger.info(f"[STREAMING] Agent '{self.name}' consuming chunks from queue")
-
-        while True:
-            try:
-                msg_type, msg_data = chunk_queue.get(timeout=120.0)  # 2 minute timeout
-                if msg_type == "done":
-                    break
-                elif msg_type == "chunk" and msg_data:
-                    accumulated_text += msg_data
-                    emitted_count += 1
-                    event = AgentStreamChunkEvent(
-                        agent_name=self.name,
-                        chunk_text=msg_data,
-                        accumulated_text=accumulated_text,
-                    )
-                    # logger.info(
-                    #     f"[STREAMING] Agent '{self.name}' emitting chunk "
-                    #     f"{emitted_count}, len={len(msg_data)}"
-                    # )
-                    self.log_handler.log(event)
-            except queue.Empty:
-                # logger.warning(
-                #     f"[STREAMING] Agent '{self.name}' timeout waiting for chunks"
-                # )
-                break
-
-        # Wait for thread to complete
-        streaming_thread.join(timeout=5.0)
-
-        # logger.info(
-        #     f"[STREAMING] Agent '{self.name}' finished, emitted {emitted_count} events"
-        # )
-
-        # Check for errors
-        if result_holder["error"] is not None:
-            error = result_holder["error"]
-
-            # Unwrap ExceptionGroup to find the real error
-            original_error = error
-            if hasattr(error, "__class__") and error.__class__.__name__.endswith("ExceptionGroup"):
-                # Python 3.11+ ExceptionGroup
-                if hasattr(error, "exceptions") and error.exceptions:
-                    original_error = error.exceptions[0]
-
-            # Check if it's an authentication error (in original or wrapped)
-            error_str = str(original_error).lower()
-            error_type = str(type(original_error).__name__)
-
-            if "authenticationerror" in error_type.lower() or "api_key" in error_str:
-                from tactus.core.exceptions import TactusRuntimeError
-
-                raise TactusRuntimeError(
-                    f"API authentication failed for agent '{self.name}': "
-                    f"Missing or invalid API key. Please configure your API key in Settings (Cmd+,)."
-                ) from error
-
-            # Unwrap ExceptionGroup so the real error is visible in logs/pcall
-            if original_error is not error:
-                logger.error(
-                    f"Agent '{self.name}' ExceptionGroup sub-exception: "
-                    f"{type(original_error).__name__}: {original_error}"
-                )
-                raise RuntimeError(
-                    f"Agent '{self.name}' failed: {type(original_error).__name__}: {original_error}"
-                ) from original_error
-            raise result_holder["error"]
-
-        # If streaming failed to produce a result, fall back to non-streaming
-        if result_holder["result"] is None:
-            logger.warning(f"Streaming produced no result for agent '{self.name}', falling back")
-            return self._turn_without_streaming(opts, prompt_context)
-
-        # Debug: log full LLM output after streaming completes
-        if os.environ.get("PLEXUS_DEBUG_LLM"):
-            self._log_llm_debug_output(result_holder["result"])
-
-        # Track new messages for this turn
-        new_messages = []
-
-        # Determine user message
+        new_messages: List[Dict[str, Any]] = []
         user_message = opts.get("message")
         if self._turn_count == 1 and not user_message and self.initial_message:
             user_message = self.initial_message
-
-        # Add user message to new_messages if present
         if user_message:
             user_msg = {"role": "user", "content": user_message}
             new_messages.append(user_msg)
             self._history.add(user_msg)
 
-        # Add assistant response to new_messages
-        if hasattr(result_holder["result"], "response"):
-            assistant_msg = {"role": "assistant", "content": result_holder["result"].response}
-
-            # Include tool calls in the message if present (before wrapping)
-            if (
-                hasattr(result_holder["result"], "tool_calls")
-                and result_holder["result"].tool_calls
-            ):
-                # Convert tool calls to JSON-serializable format
-                # logger.info("[ASYNC_STREAMING] Converting tool_calls to dict format")
-                tool_calls_list = []
-                for tc in (
-                    result_holder["result"].tool_calls.tool_calls
-                    if hasattr(result_holder["result"].tool_calls, "tool_calls")
-                    else []
-                ):
-                    tc_name, tc_args = _tool_call_name_and_args(tc)
-                    tool_calls_list.append(
-                        {
-                            "id": _tool_call_id_for_history(tc),
-                            "type": "function",
-                            "function": {
-                                "name": tc_name,
-                                "arguments": (
-                                    json.dumps(tc_args) if isinstance(tc_args, dict) else tc_args
-                                ),
-                            },
-                        }
+        current_prompt_context = prompt_context
+        forced_synthesis = False
+        while True:
+            try:
+                dspy_result = _stream_once(current_prompt_context)
+            except RuntimeError as error:
+                if str(error) == "Streaming produced no result":
+                    logger.warning(
+                        f"Streaming produced no result for agent '{self.name}', falling back"
                     )
-                # logger.info(
-                #     f"[ASYNC_STREAMING] Built tool_calls_list with "
-                #     f"{len(tool_calls_list)} items"
-                # )
-                if tool_calls_list:
-                    assistant_msg["tool_calls"] = tool_calls_list
-                    # logger.info("[ASYNC_STREAMING] Added tool_calls to assistant_msg")
+                    return self._turn_without_streaming(opts, prompt_context)
+                raise
+
+            if os.environ.get("PLEXUS_DEBUG_LLM"):
+                self._log_llm_debug_output(dspy_result)
+
+            assistant_text = getattr(dspy_result, "response", "")
+            assistant_msg: Dict[str, Any] = {"role": "assistant", "content": assistant_text}
+            tool_calls_list = self._to_tool_calls_list(dspy_result)
+            if tool_calls_list:
+                assistant_msg["tool_calls"] = tool_calls_list
 
             new_messages.append(assistant_msg)
             self._history.add(assistant_msg)
 
-            # Execute tool calls and add tool result messages to history
-            if assistant_msg.get("tool_calls"):
-                # logger.info(
-                #     f"[ASYNC_STREAMING] Agent '{self.name}' executing "
-                #     f"{len(assistant_msg['tool_calls'])} tool calls"
-                # )
-                for tc in assistant_msg["tool_calls"]:
-                    tool_name = tc["function"]["name"]
-                    tool_args_str = tc["function"]["arguments"]
-                    tool_args = (
-                        json.loads(tool_args_str)
-                        if isinstance(tool_args_str, str)
-                        else tool_args_str
-                    )
-                    tool_id = tc["id"]
+            had_tool_calls = self._execute_assistant_tool_calls(assistant_msg, new_messages)
+            if had_tool_calls:
+                current_prompt_context = self._tool_followup_prompt_context(prompt_context)
+                continue
 
-                    # logger.info(
-                    #     f"[ASYNC_STREAMING] Executing tool: {tool_name} "
-                    #     f"with args: {tool_args}"
-                    # )
+            if self._is_usable_assistant_text(assistant_text):
+                break
 
-                    # Execute the tool using toolsets
-                    tool_result = self._execute_tool(tool_name, tool_args)
-                    # logger.info(
-                    #     f"[ASYNC_STREAMING] Tool executed successfully: {tool_result}"
-                    # )
+            if forced_synthesis:
+                break
+            forced_synthesis = True
+            current_prompt_context = self._synthesis_prompt_context(prompt_context)
 
-                    # Record the tool call so Lua can check if it was called
-                    tool_primitive = getattr(self, "_tool_primitive", None)
-                    if tool_primitive:
-                        # Remove agent name prefix from tool name if present
-                        # Tool names are stored as "agent_name_tool_name" in the primitive
-                        clean_tool_name = tool_name.replace(f"{self.name}_", "")
-                        tool_primitive.record_call(
-                            clean_tool_name, tool_args, tool_result, agent_name=self.name
-                        )
-                        # logger.info(
-                        #     f"[ASYNC_STREAMING] Recorded tool call: {clean_tool_name}"
-                        # )
-
-                    # Add tool result to history in OpenAI's expected format
-                    # OpenAI requires: role="tool", tool_call_id=<id>, content=<result>
-                    tool_result_str = (
-                        json.dumps(tool_result)
-                        if isinstance(tool_result, dict)
-                        else str(tool_result)
-                    )
-                    tool_result_msg = {
-                        "role": "tool",
-                        "tool_call_id": tool_id,
-                        "name": tool_name,
-                        "content": tool_result_str,
-                    }
-                    # logger.info(
-                    #     f"[ASYNC_STREAMING] Created tool result message: {tool_result_msg}"
-                    # )
-                    new_messages.append(tool_result_msg)
-                    # logger.info(
-                    #     f"[ASYNC_STREAMING] Added tool result to new_messages, "
-                    #     f"count={len(new_messages)}"
-                    # )
-                    self._history.add(tool_result_msg)
-                    # logger.info(
-                    #     f"[ASYNC_STREAMING] Added tool result to history for "
-                    #     f"tool_call_id={tool_id}, history size={len(self._history)}"
-                    # )
-
-        # Wrap the result with message tracking
         wrapped_result = wrap_prediction(
-            result_holder["result"],
+            dspy_result,
             new_messages=new_messages,
             all_messages=self._history.get(),
         )
@@ -1330,110 +1275,47 @@ class DSPyAgentHandle:
         Returns:
             TactusResult with value, usage, and cost_stats
         """
-        # Debug: log full LLM input
         if os.environ.get("PLEXUS_DEBUG_LLM"):
             self._log_llm_debug_input(prompt_context)
 
-        # Execute the module
-        dspy_result = self._module.module(**prompt_context)
-
-        # Debug: log full LLM output
-        if os.environ.get("PLEXUS_DEBUG_LLM"):
-            self._log_llm_debug_output(dspy_result)
-
-        # Track new messages for this turn
-        new_messages = []
-
-        # Determine user message
+        new_messages: List[Dict[str, Any]] = []
         user_message = opts.get("message")
         if self._turn_count == 1 and not user_message and self.initial_message:
             user_message = self.initial_message
-
-        # Add user message to new_messages if present
         if user_message:
             user_msg = {"role": "user", "content": user_message}
             new_messages.append(user_msg)
             self._history.add(user_msg)
 
-        # Add assistant response to new_messages
-        if hasattr(dspy_result, "response"):
-            assistant_msg = {"role": "assistant", "content": dspy_result.response}
+        current_prompt_context = prompt_context
+        forced_synthesis = False
+        while True:
+            dspy_result = self._module.module(**current_prompt_context)
+            if os.environ.get("PLEXUS_DEBUG_LLM"):
+                self._log_llm_debug_output(dspy_result)
 
-            # Include tool calls in the message if present (before wrapping)
-            has_tc = hasattr(dspy_result, "tool_calls")
-            tc_value = getattr(dspy_result, "tool_calls", None)
-            logger.debug(
-                f"Agent '{self.name}' dspy_result: has_tool_calls={has_tc}, tool_calls={tc_value}"
-            )
-            if hasattr(dspy_result, "tool_calls") and dspy_result.tool_calls:
-                # Convert tool calls to JSON-serializable format
-                tool_calls_list = []
-                for tc in (
-                    dspy_result.tool_calls.tool_calls
-                    if hasattr(dspy_result.tool_calls, "tool_calls")
-                    else []
-                ):
-                    tc_name, tc_args = _tool_call_name_and_args(tc)
-                    tool_calls_list.append(
-                        {
-                            "id": _tool_call_id_for_history(tc),
-                            "type": "function",
-                            "function": {
-                                "name": tc_name,
-                                "arguments": (
-                                    json.dumps(tc_args) if isinstance(tc_args, dict) else tc_args
-                                ),
-                            },
-                        }
-                    )
-                if tool_calls_list:
-                    assistant_msg["tool_calls"] = tool_calls_list
+            assistant_text = getattr(dspy_result, "response", "")
+            assistant_msg: Dict[str, Any] = {"role": "assistant", "content": assistant_text}
+            tool_calls_list = self._to_tool_calls_list(dspy_result)
+            if tool_calls_list:
+                assistant_msg["tool_calls"] = tool_calls_list
 
             new_messages.append(assistant_msg)
             self._history.add(assistant_msg)
 
-            # Execute tool calls and add tool result messages (OpenAI requires tool
-            # messages for every tool_call_id before the next user turn). Mirrors
-            # _turn_with_streaming_async.
-            if assistant_msg.get("tool_calls"):
-                for tc in assistant_msg["tool_calls"]:
-                    tool_name = tc["function"]["name"]
-                    tool_args_str = tc["function"]["arguments"]
-                    tool_args = (
-                        json.loads(tool_args_str)
-                        if isinstance(tool_args_str, str)
-                        else tool_args_str
-                    )
-                    tool_id = tc["id"]
-                    clean_tool_name = tool_name.replace(f"{self.name}_", "")
-                    tool_primitive = getattr(self, "_tool_primitive", None)
-                    tool_result = None
-                    if tool_primitive:
-                        prior = (
-                            tool_primitive.last_call(clean_tool_name)
-                            if hasattr(tool_primitive, "last_call")
-                            else None
-                        )
-                        if prior is not None:
-                            tool_result = prior.get("result")
-                    if tool_result is None:
-                        tool_result = self._execute_tool(tool_name, tool_args)
-                    # Else: forward path already ran the tool and recorded it; only sync history.
-                    tool_result_str = (
-                        json.dumps(tool_result)
-                        if isinstance(tool_result, dict)
-                        else str(tool_result)
-                    )
-                    tool_result_msg = {
-                        "role": "tool",
-                        "tool_call_id": tool_id,
-                        "name": tool_name,
-                        "content": tool_result_str,
-                    }
-                    new_messages.append(tool_result_msg)
-                    self._history.add(tool_result_msg)
+            had_tool_calls = self._execute_assistant_tool_calls(assistant_msg, new_messages)
+            if had_tool_calls:
+                current_prompt_context = self._tool_followup_prompt_context(prompt_context)
+                continue
 
-        # Wrap the result with message tracking
+            if self._is_usable_assistant_text(assistant_text):
+                break
+
+            if forced_synthesis:
+                break
+            forced_synthesis = True
+            current_prompt_context = self._synthesis_prompt_context(prompt_context)
+
         wrapped_result = wrap_prediction(
             dspy_result,
             new_messages=new_messages,

--- a/tests/dspy/test_agent_tool_loop.py
+++ b/tests/dspy/test_agent_tool_loop.py
@@ -1,0 +1,216 @@
+from types import SimpleNamespace
+
+from tactus.dspy.agent import DSPyAgentHandle
+from tactus.protocols.cost import CostStats, UsageStats
+
+
+class _DummyToolPrimitive:
+    def __init__(self):
+        self.calls = []
+
+    def record_call(self, tool_name, args, result, agent_name=None):
+        self.calls.append((tool_name, args, result, agent_name))
+
+
+def _prediction(response="", tool_calls=None):
+    calls = tool_calls or []
+    payload = SimpleNamespace(tool_calls=calls) if calls else None
+    return SimpleNamespace(response=response, tool_calls=payload)
+
+
+def _make_agent(monkeypatch, module_fn):
+    monkeypatch.setattr(
+        DSPyAgentHandle,
+        "_build_module",
+        lambda self: SimpleNamespace(module=module_fn),
+    )
+    agent = DSPyAgentHandle(name="agent", model=None)
+    monkeypatch.setattr(agent, "_extract_last_call_stats", lambda: (UsageStats(), CostStats()))
+    monkeypatch.setattr(agent, "_emit_cost_event", lambda: None)
+    monkeypatch.setattr(
+        agent,
+        "_wrap_as_result",
+        lambda wrapped, usage, cost: SimpleNamespace(
+            output=getattr(wrapped, "response", ""), value=wrapped, usage=usage, cost_stats=cost
+        ),
+    )
+    return agent
+
+
+def test_non_streaming_tool_chain_until_final_answer(monkeypatch):
+    calls = []
+    results = [
+        _prediction(tool_calls=[{"id": "c1", "name": "agent_tool_a", "args": {"x": 1}}]),
+        _prediction(tool_calls=[{"id": "c2", "name": "agent_tool_b", "args": {"y": 2}}]),
+        _prediction(response="Final answer"),
+    ]
+
+    def module_fn(**kwargs):
+        calls.append(kwargs)
+        return results[len(calls) - 1]
+
+    agent = _make_agent(monkeypatch, module_fn)
+    agent._tool_primitive = _DummyToolPrimitive()
+    exec_calls = []
+    monkeypatch.setattr(
+        agent,
+        "_execute_tool",
+        lambda name, args: exec_calls.append((name, args)) or {"ok": name},
+    )
+
+    result = agent._turn_without_streaming(
+        {"message": "run tools"},
+        {"system_prompt": "s", "history": agent._history.to_dspy(), "user_message": "run tools"},
+    )
+
+    assert len(calls) == 3
+    assert [name for name, _ in exec_calls] == ["agent_tool_a", "agent_tool_b"]
+    assert result.value.response == "Final answer"
+    assert [c[0] for c in agent._tool_primitive.calls] == ["tool_a", "tool_b"]
+
+
+def test_non_streaming_single_tool_then_final(monkeypatch):
+    call_count = 0
+
+    def module_fn(**_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _prediction(tool_calls=[{"id": "c1", "name": "agent_tool_a", "args": {}}])
+        return _prediction(response="Done")
+
+    agent = _make_agent(monkeypatch, module_fn)
+    monkeypatch.setattr(agent, "_execute_tool", lambda _name, _args: {"ok": True})
+
+    result = agent._turn_without_streaming(
+        {"message": "do it"},
+        {"system_prompt": "s", "history": agent._history.to_dspy(), "user_message": "do it"},
+    )
+
+    assert call_count == 2
+    assert result.value.response == "Done"
+
+
+def test_non_streaming_without_tools_unchanged(monkeypatch):
+    call_count = 0
+
+    def module_fn(**_kwargs):
+        nonlocal call_count
+        call_count += 1
+        return _prediction(response="Plain answer")
+
+    agent = _make_agent(monkeypatch, module_fn)
+    result = agent._turn_without_streaming(
+        {"message": "hello"},
+        {"system_prompt": "s", "history": agent._history.to_dspy(), "user_message": "hello"},
+    )
+
+    assert call_count == 1
+    assert result.value.response == "Plain answer"
+
+
+def test_non_streaming_forces_one_synthesis_when_terminal_text_missing(monkeypatch):
+    seen_user_messages = []
+    call_count = 0
+
+    def module_fn(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        seen_user_messages.append(kwargs.get("user_message"))
+        if call_count == 1:
+            return _prediction(tool_calls=[{"id": "c1", "name": "agent_tool_a", "args": {}}])
+        if call_count == 2:
+            return _prediction(response="")
+        return _prediction(response="Synthesis answer")
+
+    agent = _make_agent(monkeypatch, module_fn)
+    monkeypatch.setattr(agent, "_execute_tool", lambda _name, _args: {"ok": True})
+
+    result = agent._turn_without_streaming(
+        {"message": "help"},
+        {"system_prompt": "s", "history": agent._history.to_dspy(), "user_message": "help"},
+    )
+
+    assert call_count == 3
+    assert seen_user_messages[0] == "help"
+    assert seen_user_messages[1] == ""
+    assert seen_user_messages[2].startswith("Provide the final user-facing answer now")
+    assert result.value.response == "Synthesis answer"
+
+
+class _DummyLogHandler:
+    supports_streaming = True
+
+    def __init__(self):
+        self.events = []
+
+    def log(self, event):
+        self.events.append(event)
+
+
+def test_streaming_tool_chain_until_final_answer(monkeypatch):
+    calls = []
+    results = [
+        _prediction(tool_calls=[{"id": "c1", "name": "agent_tool_a", "args": {"x": 1}}]),
+        _prediction(response="Final streamed answer"),
+    ]
+
+    def module_fn(**kwargs):
+        calls.append(kwargs)
+        return results[len(calls) - 1]
+
+    agent = _make_agent(monkeypatch, module_fn)
+    agent.log_handler = _DummyLogHandler()
+    monkeypatch.setattr(agent, "_execute_tool", lambda _name, _args: {"ok": True})
+
+    def fake_streamify(fn):
+        async def _wrapped(**kwargs):
+            yield fn(**kwargs)
+
+        return _wrapped
+
+    monkeypatch.setattr("dspy.streamify", fake_streamify)
+
+    result = agent._turn_with_streaming(
+        {"message": "stream tools"},
+        {"system_prompt": "s", "history": agent._history.to_dspy(), "user_message": "stream tools"},
+    )
+
+    assert len(calls) == 2
+    assert result.value.response == "Final streamed answer"
+
+
+def test_streaming_forces_one_synthesis_when_terminal_text_missing(monkeypatch):
+    seen_user_messages = []
+    call_count = 0
+
+    def module_fn(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        seen_user_messages.append(kwargs.get("user_message"))
+        if call_count == 1:
+            return _prediction(tool_calls=[{"id": "c1", "name": "agent_tool_a", "args": {}}])
+        if call_count == 2:
+            return _prediction(response="")
+        return _prediction(response="Synth final")
+
+    agent = _make_agent(monkeypatch, module_fn)
+    agent.log_handler = _DummyLogHandler()
+    monkeypatch.setattr(agent, "_execute_tool", lambda _name, _args: {"ok": True})
+
+    def fake_streamify(fn):
+        async def _wrapped(**kwargs):
+            yield fn(**kwargs)
+
+        return _wrapped
+
+    monkeypatch.setattr("dspy.streamify", fake_streamify)
+
+    result = agent._turn_with_streaming(
+        {"message": "stream help"},
+        {"system_prompt": "s", "history": agent._history.to_dspy(), "user_message": "stream help"},
+    )
+
+    assert call_count >= 3
+    assert seen_user_messages[-1].startswith("Provide the final user-facing answer now")
+    assert result.value.response == "Synth final"


### PR DESCRIPTION
## Summary
- Fix DSPy agent turns so tool calls execute in a loop until the model returns a normal assistant answer.
- Use updated conversation history after each tool result and clear the follow-up user message so tools are not repeatedly re-triggered by the original prompt.
- Run one forced synthesis call only when a terminal cycle has no tool calls and no usable assistant text.
- Add focused streaming and non-streaming tests for single-tool, multi-tool, no-tool, and no-final-text paths.

## Verification
- PYTHONPATH=/Users/ryan/Projects/Tactus pytest -q tests/dspy/test_agent_tool_loop.py
- ruff check tactus/dspy/agent.py tests/dspy/test_agent_tool_loop.py
- black --check tactus/dspy/agent.py tests/dspy/test_agent_tool_loop.py

## Kanbus
- tcts-95c709
