### PR TITLE
Fix terminal done handling in DSPy tool loop

### DIFF
--- a/project/events/2026-04-29T04:18:14.502Z__c0ef5c3c-370b-42b5-bf20-83f97dbca628.json
+++ b/project/events/2026-04-29T04:18:14.502Z__c0ef5c3c-370b-42b5-bf20-83f97dbca628.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "c0ef5c3c-370b-42b5-bf20-83f97dbca628",
+  "issue_id": "tcts-374b7763-fc81-434f-8672-09e217aed2a3",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-29T04:18:14.502Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Release CI is hanging in pytest because the DSPy agent tool loop keeps re-invoking terminal done tool calls. Fix terminal done detection for done/agent_done, add a loop cap for repeated non-terminal tools, and add regression tests.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": null,
+    "priority": 0,
+    "status": "open",
+    "title": "Fix DSPy tool loop terminal done handling"
+  }
+}

--- a/project/events/2026-04-29T04:26:30.339Z__42c79587-efa0-4cca-8e6f-70af742fa7e3.json
+++ b/project/events/2026-04-29T04:26:30.339Z__42c79587-efa0-4cca-8e6f-70af742fa7e3.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "42c79587-efa0-4cca-8e6f-70af742fa7e3",
+  "issue_id": "tcts-374b7763-fc81-434f-8672-09e217aed2a3",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T04:26:30.339Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "ad1d2bb9-7441-4fc3-bb93-3aeb617f4309"
+  }
+}

--- a/project/events/2026-04-29T04:26:34.886Z__50cab3da-1aa9-4afc-9b96-c97cf45bcf2a.json
+++ b/project/events/2026-04-29T04:26:34.886Z__50cab3da-1aa9-4afc-9b96-c97cf45bcf2a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "50cab3da-1aa9-4afc-9b96-c97cf45bcf2a",
+  "issue_id": "tcts-374b7763-fc81-434f-8672-09e217aed2a3",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-29T04:26:34.886Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-29T04:29:20.105Z__013edd3d-c6ed-4379-9f46-0575cf44d334.json
+++ b/project/events/2026-04-29T04:29:20.105Z__013edd3d-c6ed-4379-9f46-0575cf44d334.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "013edd3d-c6ed-4379-9f46-0575cf44d334",
+  "issue_id": "tcts-374b7763-fc81-434f-8672-09e217aed2a3",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T04:29:20.105Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "e8e04acb-ee37-435d-b8e7-0e28487237b4"
+  }
+}

--- a/project/issues/tcts-374b7763-fc81-434f-8672-09e217aed2a3.json
+++ b/project/issues/tcts-374b7763-fc81-434f-8672-09e217aed2a3.json
@@ -1,0 +1,25 @@
+{
+  "id": "tcts-374b7763-fc81-434f-8672-09e217aed2a3",
+  "title": "Fix DSPy tool loop terminal done handling",
+  "description": "Release CI is hanging in pytest because the DSPy agent tool loop keeps re-invoking terminal done tool calls. Fix terminal done detection for done/agent_done, add a loop cap for repeated non-terminal tools, and add regression tests.",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 0,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "ad1d2bb9-7441-4fc3-bb93-3aeb617f4309",
+      "author": "ryan",
+      "text": "Reproduced CI hang locally against origin/develop using the existing test tests/dspy/test_agent_execution.py::TestTurns::test_turn_without_streaming_records_done_tool wrapped in an 8s subprocess timeout; it timed out. Implemented terminal done handling and loop cap. On fixed branch the same test passes in ~3s. Validation: tests/dspy/test_agent_execution.py passes (89 tests), ruff check touched files passes, black --check touched files passes, direct pytest suite with only local missing-moto collection blocker ignored passes: 4203 passed, 71 skipped.",
+      "created_at": "2026-04-29T04:26:30.339474Z"
+    }
+  ],
+  "created_at": "2026-04-29T04:18:14.502105Z",
+  "updated_at": "2026-04-29T04:26:34.886331Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/tcts-374b7763-fc81-434f-8672-09e217aed2a3.json
+++ b/project/issues/tcts-374b7763-fc81-434f-8672-09e217aed2a3.json
@@ -16,10 +16,16 @@
       "author": "ryan",
       "text": "Reproduced CI hang locally against origin/develop using the existing test tests/dspy/test_agent_execution.py::TestTurns::test_turn_without_streaming_records_done_tool wrapped in an 8s subprocess timeout; it timed out. Implemented terminal done handling and loop cap. On fixed branch the same test passes in ~3s. Validation: tests/dspy/test_agent_execution.py passes (89 tests), ruff check touched files passes, black --check touched files passes, direct pytest suite with only local missing-moto collection blocker ignored passes: 4203 passed, 71 skipped.",
       "created_at": "2026-04-29T04:26:30.339474Z"
+    },
+    {
+      "id": "e8e04acb-ee37-435d-b8e7-0e28487237b4",
+      "author": "ryan",
+      "text": "Opened PR #66 into develop with terminal done handling fix: https://github.com/AnthusAI/Tactus/pull/66",
+      "created_at": "2026-04-29T04:29:20.105468Z"
     }
   ],
   "created_at": "2026-04-29T04:18:14.502105Z",
-  "updated_at": "2026-04-29T04:26:34.886331Z",
+  "updated_at": "2026-04-29T04:29:20.105468Z",
   "closed_at": null,
   "custom": {}
 }

--- a/tactus/dspy/agent.py
+++ b/tactus/dspy/agent.py
@@ -22,6 +22,7 @@ import random
 import threading
 import time
 import uuid
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 import dspy
@@ -41,6 +42,14 @@ from tactus.core.message_history_manager import MessageHistoryManager
 from tactus.utils.asyncio_helpers import clear_closed_event_loop
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_TOOL_FOLLOWUP_ROUNDS = 16
+
+
+@dataclass(frozen=True)
+class ToolExecutionOutcome:
+    had_tool_calls: bool = False
+    terminal_done_called: bool = False
 
 
 def _tool_call_name_and_args(tc: Any) -> tuple[Any, Any]:
@@ -239,6 +248,10 @@ class DSPyAgentHandle:
         response_config = kwargs.get("response") or {}
         self.response_retries = int(response_config.get("retries", 0) or 0)
         self.response_retry_delay = float(response_config.get("retry_delay", 0.0) or 0.0)
+        self.max_tool_followup_rounds = int(
+            kwargs.get("max_tool_followup_rounds", DEFAULT_MAX_TOOL_FOLLOWUP_ROUNDS)
+            or DEFAULT_MAX_TOOL_FOLLOWUP_ROUNDS
+        )
 
         # First-class Agent retry configuration (preferred over response.retries).
         #
@@ -985,7 +998,7 @@ class DSPyAgentHandle:
         tool_primitive = getattr(self, "_tool_primitive", None)
         if not tool_primitive:
             return
-        clean_tool_name = tool_name.replace(f"{self.name}_", "")
+        clean_tool_name = self._normalize_tool_name(tool_name)
         try:
             tool_primitive.record_call(
                 clean_tool_name,
@@ -996,16 +1009,27 @@ class DSPyAgentHandle:
         except Exception:
             logger.debug("Failed to record tool execution for '%s'", clean_tool_name, exc_info=True)
 
+    def _normalize_tool_name(self, tool_name: Any) -> str:
+        name = str(tool_name or "")
+        prefix = f"{self.name}_"
+        if name.startswith(prefix):
+            return name[len(prefix) :]
+        return name
+
+    def _is_terminal_done_tool(self, tool_name: Any) -> bool:
+        return self._normalize_tool_name(tool_name) == "done"
+
     def _execute_assistant_tool_calls(
         self,
         assistant_msg: Dict[str, Any],
         new_messages: List[Dict[str, Any]],
-    ) -> bool:
+    ) -> ToolExecutionOutcome:
         """Execute tool calls from an assistant message and append tool messages to history."""
         tool_calls = assistant_msg.get("tool_calls") or []
         if not tool_calls:
-            return False
+            return ToolExecutionOutcome()
 
+        terminal_done_called = False
         for tc in tool_calls:
             tool_name = tc["function"]["name"]
             tool_args_str = tc["function"]["arguments"]
@@ -1016,6 +1040,7 @@ class DSPyAgentHandle:
 
             tool_result = self._execute_tool(tool_name, tool_args)
             self._record_tool_execution(tool_name, tool_args, tool_result)
+            terminal_done_called = terminal_done_called or self._is_terminal_done_tool(tool_name)
 
             tool_result_str = (
                 json.dumps(tool_result) if isinstance(tool_result, dict) else str(tool_result)
@@ -1028,8 +1053,13 @@ class DSPyAgentHandle:
             }
             new_messages.append(tool_result_msg)
             self._history.add(tool_result_msg)
+            if terminal_done_called:
+                break
 
-        return True
+        return ToolExecutionOutcome(
+            had_tool_calls=True,
+            terminal_done_called=terminal_done_called,
+        )
 
     @staticmethod
     def _is_usable_assistant_text(text: Any) -> bool:
@@ -1173,6 +1203,7 @@ class DSPyAgentHandle:
 
         current_prompt_context = prompt_context
         forced_synthesis = False
+        tool_followup_rounds = 0
         while True:
             try:
                 dspy_result = _stream_once(current_prompt_context)
@@ -1196,8 +1227,16 @@ class DSPyAgentHandle:
             new_messages.append(assistant_msg)
             self._history.add(assistant_msg)
 
-            had_tool_calls = self._execute_assistant_tool_calls(assistant_msg, new_messages)
-            if had_tool_calls:
+            tool_outcome = self._execute_assistant_tool_calls(assistant_msg, new_messages)
+            if tool_outcome.had_tool_calls:
+                if tool_outcome.terminal_done_called:
+                    break
+                tool_followup_rounds += 1
+                if tool_followup_rounds > self.max_tool_followup_rounds:
+                    raise RuntimeError(
+                        f"Agent '{self.name}' exceeded max tool follow-up rounds "
+                        f"({self.max_tool_followup_rounds}) without producing a final response"
+                    )
                 current_prompt_context = self._tool_followup_prompt_context(prompt_context)
                 continue
 
@@ -1289,6 +1328,7 @@ class DSPyAgentHandle:
 
         current_prompt_context = prompt_context
         forced_synthesis = False
+        tool_followup_rounds = 0
         while True:
             dspy_result = self._module.module(**current_prompt_context)
             if os.environ.get("PLEXUS_DEBUG_LLM"):
@@ -1303,8 +1343,16 @@ class DSPyAgentHandle:
             new_messages.append(assistant_msg)
             self._history.add(assistant_msg)
 
-            had_tool_calls = self._execute_assistant_tool_calls(assistant_msg, new_messages)
-            if had_tool_calls:
+            tool_outcome = self._execute_assistant_tool_calls(assistant_msg, new_messages)
+            if tool_outcome.had_tool_calls:
+                if tool_outcome.terminal_done_called:
+                    break
+                tool_followup_rounds += 1
+                if tool_followup_rounds > self.max_tool_followup_rounds:
+                    raise RuntimeError(
+                        f"Agent '{self.name}' exceeded max tool follow-up rounds "
+                        f"({self.max_tool_followup_rounds}) without producing a final response"
+                    )
                 current_prompt_context = self._tool_followup_prompt_context(prompt_context)
                 continue
 

--- a/tests/dspy/test_agent_execution.py
+++ b/tests/dspy/test_agent_execution.py
@@ -45,6 +45,12 @@ class DummyToolPrimitive:
     def record_call(self, tool_name, tool_args, tool_result, agent_name=None):
         self.calls.append((tool_name, tool_args, tool_result, agent_name))
 
+    def last_call(self, tool_name):
+        for call in reversed(self.calls):
+            if call[0] == tool_name:
+                return call
+        return None
+
 
 class DummyToolCalls:
     def __init__(self, tool_calls):
@@ -446,12 +452,16 @@ class TestCostEvents:
 class TestTurns:
     def test_turn_without_streaming_records_done_tool(self, monkeypatch):
         class DummyModule:
+            calls = 0
+
             def __call__(self, **_kw):
+                self.calls += 1
                 tool_calls = DummyToolCalls([{"name": "done", "args": {"reason": "ok"}}])
                 return dspy.Prediction(response="ok", tool_calls=tool_calls)
 
+        module = DummyModule()
         agent = _make_agent(monkeypatch)
-        agent._module = types.SimpleNamespace(module=DummyModule())
+        agent._module = types.SimpleNamespace(module=module)
         agent._tool_primitive = DummyToolPrimitive()
         agent._turn_count = 1
 
@@ -463,16 +473,55 @@ class TestTurns:
         )
 
         assert result.output == "ok"
+        assert module.calls == 1
         assert agent._tool_primitive.calls[0][0] == "done"
+
+    def test_turn_without_streaming_done_skips_later_tools(self, monkeypatch):
+        class DummyModule:
+            def __call__(self, **_kw):
+                tool_calls = DummyToolCalls(
+                    [
+                        {"name": "done", "args": {"reason": "ok"}},
+                        {"name": "lookup", "args": {"id": 1}},
+                    ]
+                )
+                return dspy.Prediction(response="ok", tool_calls=tool_calls)
+
+        executed_tools = []
+        agent = _make_agent(monkeypatch)
+        agent._module = types.SimpleNamespace(module=DummyModule())
+        agent._tool_primitive = DummyToolPrimitive()
+        agent._turn_count = 1
+
+        def execute_tool(name, args):
+            executed_tools.append((name, args))
+            return {"status": "ok"}
+
+        monkeypatch.setattr(agent, "_execute_tool", execute_tool)
+        monkeypatch.setattr(agent, "_extract_last_call_stats", lambda: (UsageStats(), CostStats()))
+        monkeypatch.setattr(agent, "_emit_cost_event", lambda: None)
+
+        result = agent._turn_without_streaming(
+            {"message": "hi"}, {"history": [], "system_prompt": "", "user_message": "hi"}
+        )
+
+        assert result.output == "ok"
+        assert executed_tools == [("done", {"reason": "ok"})]
 
     def test_turn_without_streaming_initial_message(self, monkeypatch):
         class DummyModule:
-            def __call__(self, **_kw):
-                tool_calls = DummyToolCalls([{"name": "noop", "args": {"x": 1}}])
-                return dspy.Prediction(response="ok", tool_calls=tool_calls)
+            calls = 0
 
+            def __call__(self, **_kw):
+                self.calls += 1
+                if self.calls == 1:
+                    tool_calls = DummyToolCalls([{"name": "noop", "args": {"x": 1}}])
+                    return dspy.Prediction(response="ok", tool_calls=tool_calls)
+                return dspy.Prediction(response="ok")
+
+        module = DummyModule()
         agent = _make_agent(monkeypatch, initial_message="hello")
-        agent._module = types.SimpleNamespace(module=DummyModule())
+        agent._module = types.SimpleNamespace(module=module)
         agent._turn_count = 1
 
         monkeypatch.setattr(agent, "_extract_last_call_stats", lambda: (UsageStats(), CostStats()))
@@ -546,14 +595,17 @@ class TestTurns:
         agent._tool_primitive = DummyToolPrimitive()
         agent._turn_count = 1
 
+        stream_calls = {"count": 0}
         tool_calls = DummyToolCalls([types.SimpleNamespace(name="agent_tool", args={"x": 1})])
-        final_prediction = dspy.Prediction(response="done", tool_calls=tool_calls)
+        tool_prediction = dspy.Prediction(response="using tool", tool_calls=tool_calls)
+        final_prediction = dspy.Prediction(response="done")
 
         async def fake_stream():
+            stream_calls["count"] += 1
             yield DummyChunk("a")
             yield "b"
             yield 123
-            yield final_prediction
+            yield tool_prediction if stream_calls["count"] == 1 else final_prediction
 
         monkeypatch.setattr(dspy, "streamify", lambda _module: lambda **_kw: fake_stream())
         monkeypatch.setattr(
@@ -571,6 +623,59 @@ class TestTurns:
         assert any(isinstance(e, AgentTurnEvent) and e.stage == "completed" for e in handler.events)
         assert any(isinstance(e, AgentStreamChunkEvent) for e in handler.events)
         assert agent._tool_primitive.calls[0][0] == "tool"
+        assert stream_calls["count"] == 2
+
+    def test_turn_without_streaming_chained_tool_then_final_text(self, monkeypatch):
+        class DummyModule:
+            calls = 0
+
+            def __call__(self, **_kw):
+                self.calls += 1
+                if self.calls == 1:
+                    tool_calls = DummyToolCalls([{"name": "lookup", "args": {"id": 1}}])
+                    return dspy.Prediction(response="", tool_calls=tool_calls)
+                return dspy.Prediction(response="final answer")
+
+        module = DummyModule()
+        agent = _make_agent(monkeypatch)
+        agent._module = types.SimpleNamespace(module=module)
+        agent._tool_primitive = DummyToolPrimitive()
+        agent._turn_count = 1
+
+        monkeypatch.setattr(agent, "_execute_tool", lambda name, args: {"value": "tool result"})
+        monkeypatch.setattr(agent, "_extract_last_call_stats", lambda: (UsageStats(), CostStats()))
+        monkeypatch.setattr(agent, "_emit_cost_event", lambda: None)
+
+        result = agent._turn_without_streaming(
+            {"message": "hi"}, {"history": [], "system_prompt": "", "user_message": "hi"}
+        )
+
+        assert result.output == "final answer"
+        assert module.calls == 2
+        assert agent._tool_primitive.calls[0][0] == "lookup"
+
+    def test_turn_without_streaming_repeated_non_terminal_tools_hits_limit(self, monkeypatch):
+        class DummyModule:
+            calls = 0
+
+            def __call__(self, **_kw):
+                self.calls += 1
+                tool_calls = DummyToolCalls([{"name": "lookup", "args": {"id": self.calls}}])
+                return dspy.Prediction(response="", tool_calls=tool_calls)
+
+        module = DummyModule()
+        agent = _make_agent(monkeypatch, max_tool_followup_rounds=2)
+        agent._module = types.SimpleNamespace(module=module)
+        agent._turn_count = 1
+
+        monkeypatch.setattr(agent, "_execute_tool", lambda name, args: {"value": "again"})
+
+        with pytest.raises(RuntimeError, match="exceeded max tool follow-up rounds"):
+            agent._turn_without_streaming(
+                {"message": "hi"}, {"history": [], "system_prompt": "", "user_message": "hi"}
+            )
+
+        assert module.calls == 3
 
     def test_turn_with_streaming_fallback_on_no_result(self, monkeypatch):
         handler = DummyLogHandler()
@@ -889,6 +994,7 @@ class TestStreamingBranches:
         agent = _make_agent(monkeypatch, log_handler=handler)
         agent._tool_primitive = DummyToolPrimitive()
         agent._turn_count = 1
+        stream_calls = {"count": 0}
 
         tool_calls = DummyToolCalls(
             [types.SimpleNamespace(name="agent_done", args={"reason": "ok"})]
@@ -896,6 +1002,7 @@ class TestStreamingBranches:
         final_prediction = dspy.Prediction(response="done", tool_calls=tool_calls)
 
         async def fake_stream():
+            stream_calls["count"] += 1
             yield final_prediction
 
         monkeypatch.setattr(dspy, "streamify", lambda _module: lambda **_kw: fake_stream())
@@ -908,8 +1015,9 @@ class TestStreamingBranches:
         )
 
         assert result.output == "done"
+        assert stream_calls["count"] == 1
         assert agent._tool_primitive.calls[0][0] == "done"
-        assert agent._tool_primitive.calls[1][0] == "done"
+        assert len(agent._tool_primitive.calls) == 1
 
     def test_streaming_timeout_branch(self, monkeypatch):
         handler = DummyLogHandler()
@@ -961,11 +1069,14 @@ class TestStreamingBranches:
         agent = _make_agent(monkeypatch, log_handler=handler)
         agent._turn_count = 1
 
+        stream_calls = {"count": 0}
         tool_calls = DummyToolCalls([types.SimpleNamespace(name="agent_tool", args={})])
-        final_prediction = dspy.Prediction(response="ok", tool_calls=tool_calls)
+        tool_prediction = dspy.Prediction(response="ok", tool_calls=tool_calls)
+        final_prediction = dspy.Prediction(response="ok")
 
         async def fake_stream():
-            yield final_prediction
+            stream_calls["count"] += 1
+            yield tool_prediction if stream_calls["count"] == 1 else final_prediction
 
         monkeypatch.setattr(dspy, "streamify", lambda _module: lambda **_kw: fake_stream())
         monkeypatch.setattr(agent, "_execute_tool", lambda name, args: {"status": "ok"})
@@ -977,6 +1088,7 @@ class TestStreamingBranches:
         )
 
         assert result.output == "ok"
+        assert stream_calls["count"] == 2
 
     def test_streaming_empty_chunks(self, monkeypatch):
         handler = DummyLogHandler()


### PR DESCRIPTION
## Summary
- Treat `done` and agent-prefixed `agent_done` as terminal tool calls in the DSPy agent loop.
- Stop executing additional tools in the same assistant message after terminal `done`.
- Keep looping for non-terminal tools so chained tool calls can still reach final assistant text.
- Add a hard max follow-up limit for repeated non-terminal tool calls so pytest fails clearly instead of hanging.

## Local reproduction
- Against `origin/develop`, `tests/dspy/test_agent_execution.py::TestTurns::test_turn_without_streaming_records_done_tool` timed out after 8 seconds, reproducing the Release workflow hang.
- On this branch, the same test passes in about 3 seconds.

## Validation
- `python -m pytest -q tests/dspy/test_agent_execution.py` -> 89 passed
- `ruff check tactus/dspy/agent.py tests/dspy/test_agent_execution.py` -> passed
- `black --check tactus/dspy/agent.py tests/dspy/test_agent_execution.py` -> passed
- `python -m pytest -q --ignore=tests/registry/test_s3_storage.py` -> 4203 passed, 71 skipped
- `behave --tags=-skip` -> 66 features passed, 449 scenarios passed

Note: `./test-ci.sh` could not run locally because `/usr/local/bin/python3` has no Poetry installed. Full direct pytest collection without ignore is blocked locally by missing `moto` for `tests/registry/test_s3_storage.py`; CI should have the Poetry-managed dependencies.
